### PR TITLE
update: Tag 컴포넌트에 새로운 색상 조합 추가

### DIFF
--- a/src/features/tag/ui/Tag.tsx
+++ b/src/features/tag/ui/Tag.tsx
@@ -12,6 +12,7 @@ const colorCombos = [
   'bg-orange-500 border-orange-200',
   'bg-sky-500 border-sky-200',
   'bg-rose-500 border-rose-200',
+  'bg-lime-500 border-lime-200',
 ];
 
 export const Tag = ({ tag, count }: { tag: { id?: number; name?: string }; count: number }) => {


### PR DESCRIPTION
- Tag 컴포넌트의 색상 조합 배열에 'bg-lime-500 border-lime-200' 추가하여 다양한 태그 색상 지원