### PR TITLE
chore: 레이아웃 메타데이터 및 홈 페이지 제목 수정

### DIFF
--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -2,8 +2,8 @@ import type React from 'react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Blog',
+  title: 'Home',
+  description: 'Home',
 };
 
 const PublicLayout = ({ children }: { children: React.ReactNode }) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 import './globals.css';
@@ -18,11 +17,6 @@ const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
   subsets: ['latin'],
 });
-
-export const metadata: Metadata = {
-  title: 'Home',
-  description: 'Home',
-};
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
물론이죠. 분석한 코드 변경사항을 바탕으로 다음과 같이 PR 설명을 작성했습니다.

---

## 📝 작업 내용
- 루트 레이아웃에 있던 기본 메타데이터 설정을 Public 레이아웃으로 이동하여 구조를 개선했습니다.

## 🔄 주요 변경사항
- **`app/layout.tsx`**: 불필요한 기본 메타데이터를 제거했습니다.
- **`app/(public)/layout.tsx`**: Public 경로 그룹의 기본 메타데이터를 'Home'으로 설정했습니다. (기존 'Blog'에서 변경)

## 🧪 테스트 방법
1. 앱을 실행하고 Public 경로에 해당하는 페이지 (예: 홈페이지)에 접속합니다.
2. 브라우저 탭의 제목(title)이 'Home'으로 표시되는지 확인합니다.
3. 페이지 소스 보기로 `<head>` 태그 내 `<title>`과 `<meta name="description">`이 'Home'으로 설정되었는지 확인합니다.

---

<details>
<summary>🤖 AI 자동 생성 정보</summary>

**생성 시간**: 2025. 7. 20. 오후 7:47:02
**분석된 파일**: 0개 (코드: 0, 설정: 0, 문서: 0)
**AI 모델**: gemini-2.5-pro
**변경사항 요약**: 루트 레이아웃에 있던 메타데이터(페이지 제목/설명)를 하위 레이아웃으로 이동하여 정리하고, 페이지 제목을 'Blog'에서 'Home'으로 변경했습니다.

> ⚠️ 이 PR 내용은 AI가 자동으로 생성했습니다. 
> 내용을 검토하고 필요에 따라 수정해주세요.

</details>