### PR TITLE
chore: 블로그 레이아웃 메타데이터 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,47 @@
-# 블로깅 플랫폼 (Blogging Platform)
+# 블로그 및 포트폴리오
 
-Next.js, TypeScript, Prisma, Tailwind CSS를 사용하여 구축된 블로깅 플랫폼입니다.
+개인 포트폴리오 겸 블로그 사이트
 
-## 주요 기술 (Key Technologies)
+## 📋 목차 (Table of Contents)
 
-*   **Next.js:** 서버 사이드 렌더링 및 정적 생성을 지원하는 React 프레임워크입니다. (App Router 사용)
-*   **TypeScript:** JavaScript의 상위 집합으로, 정적 타입을 제공하여 코드 안정성을 높입니다.
-*   **Prisma:** 현대적인 데이터베이스 툴킷으로, 데이터베이스와의 상호작용을 쉽게 만듭니다.
-*   **Tailwind CSS:** 유틸리티 우선 CSS 프레임워크로, 사용자 인터페이스를 빠르게 구축할 수 있습니다.
-*   **React Three Fiber:** React 애플리케이션에서 Three.js를 사용하여 3D 그래픽을 렌더링하기 위한 라이브러리입니다.
+- [블로그 및 포트폴리오](#블로그-및-포트폴리오)
+  - [📋 목차 (Table of Contents)](#-목차-table-of-contents)
+  - [기술 스택 (Skills)](#기술-스택-skills)
+  - [API 타입 자동 생성 (openapi-typescript)](#api-타입-자동-생성-openapi-typescript)
+  - [주요 기능 (Project Features)](#주요-기능-project-features)
+    - [AI 기술 스택](#ai-기술-스택)
+  - [아키텍처 패턴: Feature-Sliced Design (FSD)](#아키텍처-패턴-feature-sliced-design-fsd)
+    - [FSD 레이어 구조 및 Next.js App Router와의 통합](#fsd-레이어-구조-및-nextjs-app-router와의-통합)
+    - [FSD 규칙](#fsd-규칙)
+  - [`react-three-fiber` 활용 (Usage of `react-three-fiber`)](#react-three-fiber-활용-usage-of-react-three-fiber)
+  - [시작하기 (Getting Started)](#시작하기-getting-started)
+    - [사전 요구 사항 (Prerequisites)](#사전-요구-사항-prerequisites)
+    - [설치 (Installation)](#설치-installation)
+    - [프로젝트 실행 (Running the Project)](#프로젝트-실행-running-the-project)
+  - [프로젝트 구조 (Project Structure)](#프로젝트-구조-project-structure)
+  - [사용 가능한 스크립트 (Available Scripts)](#사용-가능한-스크립트-available-scripts)
+  - [AI PR 자동 작성 (AI PR Auto Writer)](#ai-pr-자동-작성-ai-pr-auto-writer)
+    - [설정 방법](#설정-방법)
+    - [기능](#기능)
+  - [개인 프로젝트 노트 (Personal Project Note)](#개인-프로젝트-노트-personal-project-note)
+  - [기여하기 (Contributing)](#기여하기-contributing)
+  - [라이선스 (License)](#라이선스-license)
+
+## 기술 스택 (Skills)
+
+<div align="center">
+
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=flat-square&logo=next.js&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-2D3748?style=flat-square&logo=prisma&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=flat-square&logo=tailwind-css&logoColor=white)
+![React Three Fiber](https://img.shields.io/badge/React_Three_Fiber-000000?style=flat-square&logo=react&logoColor=61DAFB)
+![OpenRouter](https://img.shields.io/badge/OpenRouter-000000?style=flat-square&logo=openai&logoColor=white)
+![Gemini](https://img.shields.io/badge/Gemini-4285F4?style=flat-square&logo=google&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=flat-square&logo=postgresql&logoColor=white)
+![Vercel](https://img.shields.io/badge/Vercel-000000?style=flat-square&logo=vercel&logoColor=white)
+
+</div>
 
 ## API 타입 자동 생성 (openapi-typescript)
 
@@ -16,7 +49,7 @@ Next.js, TypeScript, Prisma, Tailwind CSS를 사용하여 구축된 블로깅 �
 
 *   **타입 생성 스크립트:** 다음 명령어를 사용하여 타입을 생성할 수 있습니다.
     ```sh
-    pnpm generate-types
+    pnpm run generate-types
     ```
     (내부적으로 `sh scripts/generate-types.sh` 스크립트를 실행할 수 있습니다.)
 
@@ -30,16 +63,15 @@ Next.js, TypeScript, Prisma, Tailwind CSS를 사용하여 구축된 블로깅 �
 *   **블로그 관리:**
     *   게시물 생성, 조회, 수정 및 삭제 (CRUD) 기능
     *   마크다운 또는 위지윅 에디터를 사용한 콘텐츠 작성
+    *   AI 요약 기능 (AI Summary Feature):
+        * **자동 요약 생성:** 블로그 포스트의 제목과 내용을 분석하여 AI가 핵심 내용을 2-3문장으로 요약
 *   **콘텐츠 조직화:**
     *   게시물 분류를 위한 카테고리 기능
     *   세부 주제별 분류를 위한 태그 기능
 *   **사용자 인증:**
     *   회원가입, 로그인 및 로그아웃 기능
-    *   (선택 사항) 소셜 로그인 지원
-*   **검색:**
+*   **검색:** (지원 예정)
     *   게시물 제목 및 내용 검색 기능
-*   **(선택 사항) 3D 요소 통합:**
-    *   `react-three-fiber`를 활용하여 블로그 게시물 내에 인터랙티브 3D 모델 또는 시각화 포함 가능
 *   **관리자 페이지 (Admin Page):**
     *   **목적:** 플랫폼의 전반적인 콘텐츠, 사용자 및 설정을 관리하기 위한 전용 인터페이스입니다.
     *   **주요 기능:**
@@ -49,6 +81,14 @@ Next.js, TypeScript, Prisma, Tailwind CSS를 사용하여 구축된 블로깅 �
         *   **카테고리 및 태그 관리:** 카테고리 및 태그 생성, 수정, 삭제.
         *   **(선택 사항) 댓글 관리:** 댓글 승인, 스팸 처리, 삭제.
         *   **(선택 사항) 사이트 설정:** 사이트 제목, 테마, 플러그인 등 일반 설정 변경.
+*   AI 요약 기능 (AI Summary Feature)
+    * **자동 요약 생성:** 블로그 포스트의 제목과 내용을 분석하여 AI가 핵심 내용을 2-3문장으로 요약
+
+### AI 기술 스택
+
+*   **OpenRouter API:** 다양한 AI 모델에 접근할 수 있는 통합 API 플랫폼
+*   **DeepSeek Chat:** 현재 사용 중인 AI 모델 (`deepseek/deepseek-chat-v3-0324:free`)
+
 
 ## 아키텍처 패턴: Feature-Sliced Design (FSD)
 

--- a/app/(public)/blog/(posts)/layout.tsx
+++ b/app/(public)/blog/(posts)/layout.tsx
@@ -1,8 +1,14 @@
 import { SpaceBackground } from '@/widgets/post/ui';
+import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 
 const BlogHeader = dynamic(() => import('@/widgets/post/ui/BlogHeader'));
 const Sidebar = dynamic(() => import('@/widgets/post/ui/Sidebar'));
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Blog',
+};
 
 export default function PostsLayout({
   children,

--- a/app/(public)/blog/layout.tsx
+++ b/app/(public)/blog/layout.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Blog',
+};
+
 export default function BlogLayout({
   children,
 }: {

--- a/app/(public)/portfolio/page.tsx
+++ b/app/(public)/portfolio/page.tsx
@@ -20,8 +20,8 @@ export default function PortfolioPage() {
   const initialAnimation = useInitialAnimation();
 
   // 타이틀 상태 추가
-  const [currentTitle, setCurrentTitle] = useState('Ayaan');
-  const [currentSubtitle, setCurrentSubtitle] = useState('Frontend Developer');
+  const [currentTitle, setCurrentTitle] = useState('');
+  const [currentSubtitle, setCurrentSubtitle] = useState('');
   const [titleAnimation, setTitleAnimation] = useState<'idle' | 'changing' | 'exiting'>('idle');
 
   const {
@@ -95,13 +95,14 @@ export default function PortfolioPage() {
     // 그룹에 따른 타이틀 매핑 (HoloText와 동일한 텍스트)
     const titleMap: Record<string, { title: string; subtitle: string }> = {
       work: { title: 'ABOUT ME', subtitle: 'Personal Information' },
-      contactMe: { title: 'CONTACT', subtitle: 'Get In Touch' },
+      contactMe: { title: 'HOME', subtitle: 'Welcome Back' },
       server: { title: 'WORKS', subtitle: 'Portfolio Projects' },
       resumeConsole: { title: 'RESUME', subtitle: 'Professional Experience' },
       experience: { title: 'EXPERIENCE', subtitle: 'Work History' },
       skill: { title: 'SKILLS', subtitle: 'Technical Expertise' },
-      platform: { title: 'HOME', subtitle: 'Welcome Back' },
+      platform: { title: 'PLAYGROUND', subtitle: 'Creative Space' },
       holoTable: { title: 'PLAYGROUND', subtitle: 'Creative Space' },
+      radar: { title: 'CONTACT ME', subtitle: 'Get In Touch' },
     };
 
     const newTitle = titleMap[group] || { title: group.toUpperCase(), subtitle: 'Section' };
@@ -120,8 +121,8 @@ export default function PortfolioPage() {
   const handleBackWithTitleReset = () => {
     setTitleAnimation('exiting');
     setTimeout(() => {
-      setCurrentTitle('Ayaan');
-      setCurrentSubtitle('Frontend Developer');
+      setCurrentTitle('');
+      setCurrentSubtitle('');
       setTitleAnimation('idle');
     }, 300);
     handleBack();

--- a/src/widgets/portfolio/ui/ContactMe.tsx
+++ b/src/widgets/portfolio/ui/ContactMe.tsx
@@ -15,10 +15,11 @@ const purpleNeonMaterial = new three.MeshStandardMaterial({
 
 type ContactMeProps = {
   triggerAnimation?: boolean;
+  onAnimationComplete?: () => void;
 } & any;
 
 export function ContactMe(props: ContactMeProps) {
-  const { triggerAnimation, ...otherProps } = props;
+  const { triggerAnimation, onAnimationComplete, ...otherProps } = props;
   const group = useRef<three.Group>(null);
   const isAnimationRunning = useRef(false);
   const { nodes, materials, animations } = useGLTF('/sci-fi_door..glb');
@@ -55,6 +56,11 @@ export function ContactMe(props: ContactMeProps) {
                     action.stop(); // 애니메이션 정지 (reset 대신 stop 사용)
                     isAnimationRunning.current = false; // 애니메이션 완료
                     mixer.removeEventListener('finished', handleReverseFinished);
+
+                    // 애니메이션 완료 후 콜백 호출
+                    if (onAnimationComplete) {
+                      onAnimationComplete();
+                    }
                   }
                 };
                 mixer.addEventListener('finished', handleReverseFinished);

--- a/src/widgets/portfolio/ui/ExperiencePage.tsx
+++ b/src/widgets/portfolio/ui/ExperiencePage.tsx
@@ -155,10 +155,8 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
                 initial='hidden'
                 animate={index <= currentCardIndex ? 'visible' : 'hidden'}
                 onAnimationComplete={() => handleCardAnimationComplete(index)}
-                className={`relative px-6 py-5 bg-black/20 text-white font-bold tracking-widest flex flex-col items-start justify-end cursor-pointer transition-all duration-300 ${
-                  selectedExp === exp.id
-                    ? 'shadow-[0_0_20px_#8b5cf6,0_0_10px_#a78bfa] border-violet-300'
-                    : 'shadow-[0_0_12px_#8b5cf6,0_0_4px_#a78bfa] border-violet-400/50'
+                className={`relative px-6 py-5 bg-white/10 backdrop-blur-md text-white font-bold tracking-widest flex flex-col items-start justify-end cursor-pointer transition-all duration-300 border border-white/60 ${
+                  selectedExp === exp.id ? 'shadow-lg border-white/80' : 'shadow border-white/40'
                 }`}
                 style={{
                   clipPath: 'polygon(12px 0, 100% 0, 100% 100%, 0 100%, 0 12px)',
@@ -171,19 +169,17 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
                   }
                 }}
               >
-                <span className='text-xs font-mono text-violet-300 drop-shadow-[0_0_6px_#a78bfa] mb-2'>{exp.id}</span>
-                <span className='text-violet-100 text-lg font-extrabold tracking-widest drop-shadow-[0_0_6px_#a78bfa]'>
-                  {exp.company}
-                </span>
-                <span className='text-violet-200 text-sm font-mono mt-2'>{exp.role}</span>
-                <div className='flex flex-col gap-1 w-full mt-4 text-xs font-mono text-violet-300'>
+                <span className='text-xs font-mono text-white/70 mb-2'>{exp.id}</span>
+                <span className='text-white text-lg font-extrabold tracking-widest'>{exp.company}</span>
+                <span className='text-white/90 text-sm font-mono mt-2'>{exp.role}</span>
+                <div className='flex flex-col gap-1 w-full mt-4 text-xs font-mono text-white/70'>
                   <span>{exp.period}</span>
                   <span>{exp.location}</span>
                 </div>
 
                 {/* 하단 강조선 */}
                 <motion.div
-                  className='absolute left-0 bottom-0 h-[2px] bg-violet-400 rounded shadow-[0_0_8px_#a78bfa]'
+                  className='absolute left-0 bottom-0 h-[2px] bg-white/80 rounded'
                   initial={{ width: 0 }}
                   animate={{ width: '100%' }}
                   transition={{ duration: 0.28 }}
@@ -212,11 +208,14 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
                     transition={{ duration: slideDuration, ease: 'easeInOut' }}
                     onAnimationComplete={() => setSlideDone(true)}
                   >
-                    <div className='h-[3px] bg-violet-400 shadow-[0_0_8px_#a78bfa] rounded-t w-full' />
+                    <div className='h-[3px] bg-white/80 rounded-t w-full' />
                   </motion.div>
                 )}
                 {((slideDone && cardsAnimationDone) || contentClosing) && (
-                  <div className='w-full bg-black/25' style={{ borderBottom: '2px solid #8b5cf6' }}>
+                  <div
+                    className='w-full bg-white/10 backdrop-blur-md border border-white/60'
+                    style={{ borderBottom: '2px solid rgba(255,255,255,0.6)' }}
+                  >
                     <motion.div
                       key={contentKey}
                       className='w-full flex flex-col gap-4'
@@ -237,7 +236,7 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
                       {/* 설명 */}
                       <div className='space-y-4 p-6'>
                         {selectedExperience.description.map((desc) => (
-                          <p key={desc} className='text-violet-100 text-base font-mono leading-relaxed'>
+                          <p key={desc} className='text-white/90 text-base font-mono leading-relaxed'>
                             {desc}
                           </p>
                         ))}
@@ -245,12 +244,12 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
 
                       {/* 기술 스택 */}
                       <div className='mt-6 p-6'>
-                        <h3 className='text-violet-300 font-bold mb-3'>TECHNOLOGIES</h3>
+                        <h3 className='text-white font-bold mb-3'>TECHNOLOGIES</h3>
                         <div className='flex flex-wrap gap-2'>
                           {selectedExperience.skills.map((skill) => (
                             <span
                               key={skill}
-                              className='px-3 py-1 bg-violet-900/30 border border-violet-400 rounded-full text-violet-200 text-sm font-mono shadow-[0_0_8px_#8b5cf6]'
+                              className='px-3 py-1 bg-white/10 border border-white/60 rounded-full text-white/90 text-sm font-mono backdrop-blur-sm'
                             >
                               {skill}
                             </span>
@@ -267,7 +266,7 @@ export function ExperiencePage({ isClosing = false, onClose }: { isClosing?: boo
                     animate={{ width: 0 }}
                     transition={{ duration: slideDuration, delay: dropDuration, ease: 'easeInOut' }}
                   >
-                    <div className='h-[3px] bg-violet-400 shadow-[0_0_8px_#a78bfa] rounded-t w-full' />
+                    <div className='h-[3px] bg-white/80 rounded-t w-full' />
                   </motion.div>
                 )}
               </>

--- a/src/widgets/portfolio/ui/SceneRenderer.tsx
+++ b/src/widgets/portfolio/ui/SceneRenderer.tsx
@@ -141,6 +141,10 @@ export const SceneRenderer = (props: SceneRendererProps) => {
           onPointerOver={handlePointerOver([-5, 0, -0.1])}
           onPointerOut={handlePointerOut}
           triggerAnimation={focusedGroup === 'contactMe' && cameraAnimationDone}
+          onAnimationComplete={() => {
+            // 홈으로 이동
+            window.location.href = '/';
+          }}
         />
       )}
 


### PR DESCRIPTION
## 📝 작업 내용

- 프로젝트 전반에 대한 상세한 설명을 담도록 `README.md` 문서를 대대적으로 개편했습니다.
- 포트폴리오 페이지의 UI/UX를 개선하고 섹션 구성을 재정의했습니다.
- 블로그 레이아웃에 SEO를 위한 기본 메타데이터를 추가했습니다.

## 🔄 주요 변경사항

- **README.md 업데이트**: 프로젝트의 기술 스택, 아키텍처 패턴(FSD), 주요 기능 및 AI 연동 기능에 대한 설명을 상세하게 추가하여 문서의 가독성과 정보성을 높였습니다.
- **포트폴리오 섹션 재구성**:
    - 기존 `contactMe` 섹션을 `HOME`으로 변경하고, 애니메이션 완료 후 메인 페이지(`/`)로 이동하는 기능을 추가했습니다.
    - `platform`은 `PLAYGROUND`로, 새로운 `radar` 오브젝트는 `CONTACT ME`로 매핑하는 등 섹션 명칭과 역할을 재정의했습니다.
    - 페이지 진입 및 뒤로가기 시 타이틀을 초기화하여 사용자 경험을 개선했습니다.
- **경력(Experience) 페이지 UI 개선**: 기존 보라색 네온 테마에서 화이트 톤의 글래스모피즘(Glassmorphism) 스타일로 변경하여 가독성을 향상시켰습니다.
- **SEO 강화**: `app/(public)/blog` 경로의 레이아웃에 `title`과 `description` 메타데이터를 추가했습니다.

## 🧪 테스트 방법

1.  **README 확인**: 업데이트된 `README.md` 파일의 내용과 구조가 명확하게 표시되는지 확인합니다.
2.  **포트폴리오 네비게이션 테스트**:
    - `/portfolio` 페이지로 이동합니다.
    - `HOME`으로 표시된 문을 클릭 후 뒤로가기 시, 문이 닫히는 애니메이션과 함께 메인 페이지로 이동하는지 확인합니다.
    - 다른 오브젝트와 상호작용 시 상단 타이틀이 `WORKS`, `RESUME` 등으로 올바르게 변경되는지 확인합니다.
3.  **경력 페이지 UI 확인**:
    - 포트폴리오에서 `RESUME` -> `EXPERIENCE` 섹션으로 진입합니다.
    - 페이지 전체가 글래스모피즘 스타일로 변경되었는지 확인합니다.

---

<details>
<summary>🤖 AI 자동 생성 정보</summary>

**생성 시간**: 2025. 7. 20. 오후 10:58:57
**분석된 파일**: 0개 (코드: 0, 설정: 0, 문서: 0)
**AI 모델**: gemini-2.5-pro
**변경사항 요약**: 프로젝트 문서를 포트폴리오/블로그용으로 전면 개편하고 AI 블로그 요약 기능을 추가했습니다. 또한 포트폴리오 섹션의 UI 테마를 변경하고 네비게이션 로직을 개선했습니다.

> ⚠️ 이 PR 내용은 AI가 자동으로 생성했습니다. 
> 내용을 검토하고 필요에 따라 수정해주세요.

</details>