### PR TITLE
chore: AI 코드 리뷰 워크플로 자동 실행 비활성화

### DIFF
--- a/.github/workflows/ai-pr.yml
+++ b/.github/workflows/ai-pr.yml
@@ -1,8 +1,8 @@
 name: AI PR 자동 작성
+# 임시 비활성화: 필요 시 Actions에서 workflow_dispatch로만 수동 실행
 on:
-  pull_request:
-    types: [opened, synchronize]
-    
+  workflow_dispatch:
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,8 +1,8 @@
 name: AI 코드 리뷰 (Gemini AI 버전)
+# 임시 비활성화: 필요 시 Actions에서 workflow_dispatch로만 수동 실행
 on:
-  pull_request:
-    types: [opened, synchronize]
-    
+  workflow_dispatch:
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,22 +1,8 @@
 name: '🔀 Gemini Dispatch'
 
+# 임시 비활성화: AI 리뷰/디스패치 자동 실행 중지 (수동만 허용)
 on:
-  pull_request_review_comment:
-    types:
-      - 'created'
-  pull_request_review:
-    types:
-      - 'submitted'
-  pull_request:
-    types:
-      - 'opened'
-  issues:
-    types:
-      - 'opened'
-      - 'reopened'
-  issue_comment:
-    types:
-      - 'created'
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -18,6 +18,8 @@ defaults:
 
 jobs:
   review:
+    # 임시 비활성화: Gemini AI 코드 리뷰 자동 실행 중지
+    if: false
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
     permissions:


### PR DESCRIPTION
## Summary
- `code-review.yml`, `ai-pr.yml`, `gemini-dispatch.yml`의 PR 자동 트리거 제거
- `gemini-review.yml` job에 `if: false`로 실행 차단
- 필요 시 Actions에서 `workflow_dispatch`로만 수동 실행 가능

## Test plan
- [ ] 새 PR에서 AI 코드 리뷰 / AI PR 워크플로가 자동 실행되지 않는지 확인
- [ ] Actions 탭에서 해당 워크플로가 수동 실행만 가능한지 확인