### PR TITLE
feat: 카테고리 사이드바 트리 계층 구조 지원

### DIFF
--- a/.cursor/rules/api-openapi-types.mdc
+++ b/.cursor/rules/api-openapi-types.mdc
@@ -1,0 +1,30 @@
+---
+description: API/Swagger 변경 시 openapi-typescript 타입 재생성 필수
+globs: app/api/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# API 변경 후 타입 동기화
+
+`app/api/**`의 라우트·Swagger 주석을 바꾸면 OpenAPI 타입이 어긋날 수 있다.
+
+## 필수
+
+1. Swagger(`@swagger`) / request·response shape 변경 후 **반드시** 실행:
+   ```bash
+   pnpm run generate-types
+   ```
+2. 생성물: `src/shared/api/openapi-types.ts`
+3. 클라이언트/엔티티에서 API 응답을 쓸 때는 OpenAPI 타입을 기준으로 맞춘다.
+   - optional 필드(`slug?` 등)는 `?? ''` 등으로 정규화하거나 전용 mapper 사용
+   - 예: `toCategoryListItems()`
+
+## 하지 말 것
+
+- Swagger만 바꾸고 `generate-types`를 생략한 채 수동으로 `openapi-types.ts`를 대충 수정
+- OpenAPI optional을 무시하고 필수 `string`에 그대로 할당
+
+## 확인
+
+- [ ] `pnpm run generate-types` 실행됨
+- [ ] 관련 entity/feature 타입이 새 OpenAPI와 호환됨

--- a/.cursor/rules/server-client-boundary.mdc
+++ b/.cursor/rules/server-client-boundary.mdc
@@ -1,0 +1,41 @@
+---
+description: Next.js App Router Server/Client 컴포넌트 경계
+globs: "{app,src}/**/*.{ts,tsx}"
+alwaysApply: false
+---
+
+# Server vs Client Component
+
+기본은 **Server Component**. `'use client'`는 필요할 때만 추가한다.
+상세 가이드: `ARCHITECTURE.md`의 Server/Client 섹션.
+
+## Server로 둘 것
+
+- `app/**/page.tsx`, `layout.tsx`, `loading.tsx` (인터랙션 없을 때)
+- `app/api/**/route.ts`
+- `src/entities/**/lib/*` 순수 함수 (트리 빌드, DTO 정규화 등)
+
+## Client로 둘 것 (`'use client'`)
+
+- `useState` / `useEffect` / `useTransition`
+- 클릭·폼·모달 open 상태
+- `useRouter` / `usePathname`, framer-motion
+- TanStack Query (`useQuery` 등)
+- `window` / `localStorage` 등 브라우저 API
+
+## 패턴
+
+```tsx
+// ✅ app/.../page.tsx (Server) → Client 위젯만 조합
+export default function Page() {
+  return <CategoryManagement />;
+}
+
+// ✅ entities/.../lib/build-category-tree.ts — 'use client' 없음
+// ✅ widgets/.../CategoryTree.tsx — 접기/클릭 있으므로 'use client'
+```
+
+## 하지 말 것
+
+- 정적 마크업·metadata만 있는 파일에 `'use client'`
+- Client 경계를 부모까지 불필요하게 확장

--- a/.cursor/rules/server-client-boundary.mdc
+++ b/.cursor/rules/server-client-boundary.mdc
@@ -6,16 +6,23 @@ alwaysApply: false
 
 # Server vs Client Component
 
-기본은 **Server Component**. `'use client'`는 필요할 때만 추가한다.
+라우트(`page`/`layout`) 기본 실행 환경은 **Server**.  
+`'use client'`는 **Client Component 진입 경계**다. 지시어가 없는 파일 전부가 Server Component는 아니다.  
 상세 가이드: `ARCHITECTURE.md`의 Server/Client 섹션.
 
 ## Server로 둘 것
 
 - `app/**/page.tsx`, `layout.tsx`, `loading.tsx` (인터랙션 없을 때)
 - `app/api/**/route.ts`
-- `src/entities/**/lib/*` 순수 함수 (트리 빌드, DTO 정규화 등)
+- 서버 전용 모듈은 `server-only`로 보호
 
-## Client로 둘 것 (`'use client'`)
+## 공유 모듈 (`'use client'` 없음)
+
+- `src/entities/**/lib/*` 순수 함수 (트리 빌드, DTO 정규화 등)
+- Server/Client 모두 import 가능. Client에서 import하면 **Client 번들 일부**가 됨
+- 예: `category-selector.tsx`(`'use client'`) → `build-category-tree.ts`
+
+## Client 경계 (`'use client'`)
 
 - `useState` / `useEffect` / `useTransition`
 - 클릭·폼·모달 open 상태
@@ -31,11 +38,14 @@ export default function Page() {
   return <CategoryManagement />;
 }
 
-// ✅ entities/.../lib/build-category-tree.ts — 'use client' 없음
+// ✅ entities/.../lib/build-category-tree.ts — 공유 모듈 ('use client' 없음)
+// ✅ features/.../category-selector.tsx — Client 경계에서 위 lib를 import
 // ✅ widgets/.../CategoryTree.tsx — 접기/클릭 있으므로 'use client'
 ```
 
 ## 하지 말 것
 
+- `'use client'` 없음을 Server Component와 동일시
 - 정적 마크업·metadata만 있는 파일에 `'use client'`
 - Client 경계를 부모까지 불필요하게 확장
+- 서버 전용 코드를 공유 모듈에 섞어 Client로 유출

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit"
   },
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "prisma.pinToPrisma6": true
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@
 │   ├── widgets/           # 독립적으로 재사용 가능한 UI 컴포넌트
 │   ├── features/          # 기능 단위 모듈 (예: 로그인, 회원가입)
 │   ├── entities/          # 도메인 엔티티 (예: User, Product)
-│   ├── shared/            # 공용 모듈 (예: Button, Modal)
+│   ├── shared/            # 공용 유틸 (예: Button, Modal)
 │   └── shadcn-ui/         # ShadCN UI 컴포넌트 관리 디렉토리
 │       ├── components/    # ShadCN의 기본 컴포넌트
 │       │   ├── Button.tsx
@@ -124,7 +124,7 @@ views/
 ---
 
 ### **7. src/shared/**
-- 애플리케이션 전반에서 사용되는 공용 모듈을 관리합니다.
+- 애플리케이션 전반에서 사용되는 공용 유틸을 관리합니다.
 - 예: 버튼, 모달, 유틸리티 함수 등.
 
 ---
@@ -195,11 +195,70 @@ export function cn(...inputs: ClassValue[]) {
 
 ## **폴더 구조 설계 원칙**
 
-1. **관심사 분리**: 페이지, 상태 관리, 공용 모듈을 명확히 구분.
+1. **관심사 분리**: 페이지, 상태 관리, 공용 유틸을 명확히 구분.
 2. **재사용성**: 위젯과 공용 컴포넌트를 통해 코드 중복 최소화.
 3. **확장성**: 새로운 기능 추가 시 기존 코드에 최소한의 영향을 미침.
 
 ---
 
-이 구조를 통해 FSD와 ShadCN UI를 효과적으로 결합하여 생산성과 유지보수성을 극대화할 수 있습니다!
+## **Server Component vs Client Component**
 
+이 프로젝트는 Next.js App Router의 **React Server Components(RSC)** 를 기본으로 씁니다.  
+파일 상단에 `'use client'`가 없으면 **서버 컴포넌트**, 있으면 **클라이언트 컴포넌트**입니다.
+
+### 기본 규칙
+
+| 구분 | 위치 / 예시 | 역할 |
+|------|-------------|------|
+| **Server (기본)** | `app/**/page.tsx`, `layout.tsx`, `loading.tsx`, `app/api/**/route.ts` | 라우트 진입, 데이터 fetch, SEO/metadata, API |
+| **Server 가능** | `src/entities/**/lib/*` (순수 함수, `'use client'` 없음) | 트리 빌드, 도메인 변환 등 공유 유틸 |
+| **Client** | `'use client'`가 있는 `widgets` / `features` UI | 클릭·폼·모달·애니메이션·브라우저 API·React Query |
+
+### 언제 클라이언트로 두나
+
+다음이 필요하면 `'use client'`를 둡니다.
+
+- `useState` / `useEffect` / `useTransition` 등 훅
+- `onClick`, 폼 입력, 모달 open 상태
+- `framer-motion`, `next/navigation`의 `useRouter` / `usePathname`
+- TanStack Query (`useQuery`) 등 브라우저 캐시 훅
+- `window`, `localStorage` 등 브라우저 전용 API
+
+데이터만 가져와 그리기만 하면 **서버 컴포넌트**로 유지합니다.
+
+### 이 프로젝트에서의 실제 배치
+
+```plaintext
+app/
+  (public)/blog/(posts)/.../page.tsx   # Server: 포스트 fetch + 렌더 (예: post detail)
+  (public)/blog/(posts)/layout.tsx     # Server: 셸 조립 (자식에 Client 위젯 포함 가능)
+  (protect)/admin/categories/page.tsx  # Server: 페이지 껍데기
+  api/category/**/route.ts             # Server: REST API
+
+src/
+  entities/category/lib/               # Server·Client 모두 import 가능 (순수 함수)
+    build-category-tree.ts
+    to-category-list-item.ts
+  widgets/post/ui/
+    Sidebar.tsx                        # Client: 라우팅·사이드바 토글
+    CategoryTree.tsx                   # Client: 접기/펼치기·클릭
+  widgets/admin/category/              # Client: 관리자 CRUD·모달
+  features/category/ui/category-form.tsx  # Client: react-hook-form
+```
+
+### 조합 패턴 (권장)
+
+1. **`app/.../page.tsx`(Server)** 가 데이터를 가져오거나, 클라이언트 위젯만 마운트한다.
+2. **인터랙션 UI는 Client 위젯/피처**로 분리한다 (`CategoryTree`, `CategoryManagement` 등).
+3. **트리 변환·타입 정규화 같은 순수 로직**은 `entities/**/lib`에 두고 Server/Client 어디서든 import한다.
+4. Client 경계를 불필요하게 넓히지 않는다. 정적 마크업·metadata·초기 HTML은 Server에 남긴다.
+
+### 체크리스트
+
+- [ ] 이 파일에 훅/이벤트/브라우저 API가 있는가? → 있으면 Client
+- [ ] 없으면 Server로 두고, 필요한 자식만 Client로 분리했는가?
+- [ ] API 변경 시 `pnpm run generate-types`로 OpenAPI 타입을 맞췄는가?
+
+---
+
+이 구조를 통해 FSD와 ShadCN UI를 효과적으로 결합하여 생산성과 유지보수성을 극대화할 수 있습니다!

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@
 │   ├── widgets/           # 독립적으로 재사용 가능한 UI 컴포넌트
 │   ├── features/          # 기능 단위 모듈 (예: 로그인, 회원가입)
 │   ├── entities/          # 도메인 엔티티 (예: User, Product)
-│   ├── shared/            # 공용 유틸 (예: Button, Modal)
+│   ├── shared/            # 공용 코드 (예: ui, lib, config)
 │   └── shadcn-ui/         # ShadCN UI 컴포넌트 관리 디렉토리
 │       ├── components/    # ShadCN의 기본 컴포넌트
 │       │   ├── Button.tsx
@@ -124,8 +124,11 @@ views/
 ---
 
 ### **7. src/shared/**
-- 애플리케이션 전반에서 사용되는 공용 유틸을 관리합니다.
-- 예: 버튼, 모달, 유틸리티 함수 등.
+- 애플리케이션 전반에서 재사용되는 공용 코드를 관리합니다.
+- 주요 하위 디렉토리:
+  - `ui/`: 공용 UI 컴포넌트 (예: `AuthSidebar`, `Modal`, `Button`)
+  - `lib/`: 인프라·라이브러리 래퍼 (예: `db`, `swagger`, `supabase`)
+  - `config`/`consts`/`utils`: 설정값, 상수, 순수 유틸리티 함수
 
 ---
 
@@ -195,7 +198,7 @@ export function cn(...inputs: ClassValue[]) {
 
 ## **폴더 구조 설계 원칙**
 
-1. **관심사 분리**: 페이지, 상태 관리, 공용 유틸을 명확히 구분.
+1. **관심사 분리**: 페이지, 상태 관리, 공용 코드를 명확히 구분.
 2. **재사용성**: 위젯과 공용 컴포넌트를 통해 코드 중복 최소화.
 3. **확장성**: 새로운 기능 추가 시 기존 코드에 최소한의 영향을 미침.
 
@@ -204,15 +207,20 @@ export function cn(...inputs: ClassValue[]) {
 ## **Server Component vs Client Component**
 
 이 프로젝트는 Next.js App Router의 **React Server Components(RSC)** 를 기본으로 씁니다.  
-파일 상단에 `'use client'`가 없으면 **서버 컴포넌트**, 있으면 **클라이언트 컴포넌트**입니다.
+`app/**/page.tsx`, `layout.tsx` 등 **라우트 진입점의 기본 실행 환경은 Server**입니다.  
+`'use client'`는 **Client Component 진입 경계**입니다. 이 지시어가 없는 파일 전부가 Server Component인 것은 아닙니다.  
+Client Component가 공유 모듈을 import하면, 그 모듈도 **Client 번들의 일부**가 됩니다.  
+(예: `src/features/admin/post/ui/category-selector.tsx`가 `'use client'`를 두고 `src/entities/category/lib/build-category-tree.ts`를 import하는 구조.)  
+서버에서만 써야 하는 코드(시크릿, DB 직접 접근 등)는 `server-only`로 별도 보호합니다.
 
 ### 기본 규칙
 
 | 구분 | 위치 / 예시 | 역할 |
 |------|-------------|------|
 | **Server (기본)** | `app/**/page.tsx`, `layout.tsx`, `loading.tsx`, `app/api/**/route.ts` | 라우트 진입, 데이터 fetch, SEO/metadata, API |
-| **Server 가능** | `src/entities/**/lib/*` (순수 함수, `'use client'` 없음) | 트리 빌드, 도메인 변환 등 공유 유틸 |
-| **Client** | `'use client'`가 있는 `widgets` / `features` UI | 클릭·폼·모달·애니메이션·브라우저 API·React Query |
+| **공유 모듈** | `'use client'` 없는 `src/entities/**/lib/*` 등 | 순수 함수·변환 로직. Server/Client 모두 import 가능(Client에서 import 시 Client 번들에 포함) |
+| **Client 경계** | `'use client'`가 있는 `widgets` / `features` UI | 클릭·폼·모달·애니메이션·브라우저 API·React Query |
+| **서버 전용** | `server-only`를 import한 모듈 | Client 번들로 새면 안 되는 코드 |
 
 ### 언제 클라이언트로 두나
 
@@ -236,9 +244,11 @@ app/
   api/category/**/route.ts             # Server: REST API
 
 src/
-  entities/category/lib/               # Server·Client 모두 import 가능 (순수 함수)
-    build-category-tree.ts
+  entities/category/lib/               # 공유 모듈: Server·Client 모두 import 가능 (순수 함수)
+    build-category-tree.ts             # 예: category-selector(Client)에서도 import
     to-category-list-item.ts
+  features/admin/post/ui/
+    category-selector.tsx              # Client 경계 ('use client') → build-category-tree import
   widgets/post/ui/
     Sidebar.tsx                        # Client: 라우팅·사이드바 토글
     CategoryTree.tsx                   # Client: 접기/펼치기·클릭
@@ -250,8 +260,9 @@ src/
 
 1. **`app/.../page.tsx`(Server)** 가 데이터를 가져오거나, 클라이언트 위젯만 마운트한다.
 2. **인터랙션 UI는 Client 위젯/피처**로 분리한다 (`CategoryTree`, `CategoryManagement` 등).
-3. **트리 변환·타입 정규화 같은 순수 로직**은 `entities/**/lib`에 두고 Server/Client 어디서든 import한다.
+3. **트리 변환·타입 정규화 같은 순수 로직**은 `entities/**/lib` 공유 모듈에 둔다. `'use client'`가 없어도 Client에서 import되면 Client 번들에 포함된다.
 4. Client 경계를 불필요하게 넓히지 않는다. 정적 마크업·metadata·초기 HTML은 Server에 남긴다.
+5. 서버 전용 코드는 `server-only`로 보호한다.
 
 ### 체크리스트
 

--- a/app/(protect)/admin/categories/page.tsx
+++ b/app/(protect)/admin/categories/page.tsx
@@ -1,0 +1,5 @@
+import { CategoryManagement } from '@/widgets/admin/category';
+
+export default function AdminCategoriesPage() {
+  return <CategoryManagement />;
+}

--- a/app/api/category/[slug]/route.ts
+++ b/app/api/category/[slug]/route.ts
@@ -215,6 +215,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
  *               description:
  *                 type: string
  *                 nullable: true
+ *               parentId:
+ *                 type: integer
+ *                 nullable: true
+ *                 description: 부모 카테고리 ID (루트면 null)
  *     responses:
  *       200:
  *         description: Category updated successfully
@@ -258,11 +262,59 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
     }
 
-    const { name, description } = await request.json();
+    const { name, description, parentId } = await request.json();
     const categoryId = Number.parseInt(slug);
 
     if (!name?.trim()) {
       return NextResponse.json({ error: 'Category name is required' }, { status: 400 });
+    }
+
+    const current = await prisma.category.findUnique({ where: { id: categoryId } });
+    if (!current) {
+      return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+    }
+
+    let normalizedParentId: number | null = null;
+    if (parentId != null && parentId !== '') {
+      const parsedParentId = Number(parentId);
+      if (Number.isNaN(parsedParentId)) {
+        return NextResponse.json({ error: 'Invalid parentId' }, { status: 400 });
+      }
+      if (parsedParentId === categoryId) {
+        return NextResponse.json({ error: 'Category cannot be its own parent' }, { status: 400 });
+      }
+
+      const allCategories = await prisma.category.findMany({
+        select: { id: true, parentId: true },
+      });
+      const blocked = new Set<number>([categoryId]);
+      const childrenByParent = new Map<number, number[]>();
+      for (const category of allCategories) {
+        if (category.parentId == null) continue;
+        const list = childrenByParent.get(category.parentId) ?? [];
+        list.push(category.id);
+        childrenByParent.set(category.parentId, list);
+      }
+      const stack = [categoryId];
+      while (stack.length > 0) {
+        const currentId = stack.pop();
+        if (currentId == null) continue;
+        for (const childId of childrenByParent.get(currentId) ?? []) {
+          if (blocked.has(childId)) continue;
+          blocked.add(childId);
+          stack.push(childId);
+        }
+      }
+
+      if (blocked.has(parsedParentId)) {
+        return NextResponse.json({ error: 'Cannot set a descendant as parent' }, { status: 400 });
+      }
+
+      const parent = await prisma.category.findUnique({ where: { id: parsedParentId } });
+      if (!parent) {
+        return NextResponse.json({ error: 'Parent category not found' }, { status: 400 });
+      }
+      normalizedParentId = parsedParentId;
     }
 
     // Check for duplicate category name, excluding current category
@@ -287,6 +339,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
         name: name.trim(),
         slug: createSlug(name),
         description: description?.trim(),
+        parentId: normalizedParentId,
       },
     });
 
@@ -355,6 +408,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ s
         _count: {
           select: {
             posts: true,
+            children: true,
           },
         },
       },
@@ -366,6 +420,10 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ s
 
     if (category._count.posts > 0) {
       return NextResponse.json({ error: 'Cannot delete category that contains posts' }, { status: 400 });
+    }
+
+    if (category._count.children > 0) {
+      return NextResponse.json({ error: 'Cannot delete category that has child categories' }, { status: 400 });
     }
 
     await prisma.category.delete({

--- a/app/api/category/[slug]/route.ts
+++ b/app/api/category/[slug]/route.ts
@@ -1,5 +1,6 @@
 // app/api/category/[slug]/route.ts
 import { NextResponse } from 'next/server';
+import { parseCategoryParentId } from '@/entities/category';
 import prisma from '@/shared/lib/db';
 import { createSlug } from '@/shared/utils/create-slug';
 import { auth } from '@/shared/utils/auth';
@@ -262,8 +263,10 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
     }
 
-    const { name, description, parentId } = await request.json();
+    const body = await request.json();
+    const { name, description, parentId } = body;
     const categoryId = Number.parseInt(slug);
+    const shouldUpdateParentId = Object.hasOwn(body, 'parentId');
 
     if (!name?.trim()) {
       return NextResponse.json({ error: 'Category name is required' }, { status: 400 });
@@ -275,46 +278,50 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
     }
 
     let normalizedParentId: number | null = null;
-    if (parentId != null && parentId !== '') {
-      const parsedParentId = Number(parentId);
-      if (Number.isNaN(parsedParentId)) {
-        return NextResponse.json({ error: 'Invalid parentId' }, { status: 400 });
-      }
-      if (parsedParentId === categoryId) {
-        return NextResponse.json({ error: 'Category cannot be its own parent' }, { status: 400 });
-      }
-
-      const allCategories = await prisma.category.findMany({
-        select: { id: true, parentId: true },
-      });
-      const blocked = new Set<number>([categoryId]);
-      const childrenByParent = new Map<number, number[]>();
-      for (const category of allCategories) {
-        if (category.parentId == null) continue;
-        const list = childrenByParent.get(category.parentId) ?? [];
-        list.push(category.id);
-        childrenByParent.set(category.parentId, list);
-      }
-      const stack = [categoryId];
-      while (stack.length > 0) {
-        const currentId = stack.pop();
-        if (currentId == null) continue;
-        for (const childId of childrenByParent.get(currentId) ?? []) {
-          if (blocked.has(childId)) continue;
-          blocked.add(childId);
-          stack.push(childId);
+    if (shouldUpdateParentId) {
+      if (parentId != null && parentId !== '') {
+        const parsedParentId = parseCategoryParentId(parentId);
+        if (parsedParentId == null) {
+          return NextResponse.json({ error: 'Invalid parentId' }, { status: 400 });
         }
-      }
+        if (parsedParentId === categoryId) {
+          return NextResponse.json({ error: 'Category cannot be its own parent' }, { status: 400 });
+        }
 
-      if (blocked.has(parsedParentId)) {
-        return NextResponse.json({ error: 'Cannot set a descendant as parent' }, { status: 400 });
-      }
+        const allCategories = await prisma.category.findMany({
+          select: { id: true, parentId: true },
+        });
+        const blocked = new Set<number>([categoryId]);
+        const childrenByParent = new Map<number, number[]>();
+        for (const category of allCategories) {
+          if (category.parentId == null) continue;
+          const list = childrenByParent.get(category.parentId) ?? [];
+          list.push(category.id);
+          childrenByParent.set(category.parentId, list);
+        }
+        const stack = [categoryId];
+        while (stack.length > 0) {
+          const currentId = stack.pop();
+          if (currentId == null) continue;
+          for (const childId of childrenByParent.get(currentId) ?? []) {
+            if (blocked.has(childId)) continue;
+            blocked.add(childId);
+            stack.push(childId);
+          }
+        }
 
-      const parent = await prisma.category.findUnique({ where: { id: parsedParentId } });
-      if (!parent) {
-        return NextResponse.json({ error: 'Parent category not found' }, { status: 400 });
+        if (blocked.has(parsedParentId)) {
+          return NextResponse.json({ error: 'Cannot set a descendant as parent' }, { status: 400 });
+        }
+
+        const parent = await prisma.category.findUnique({ where: { id: parsedParentId } });
+        if (!parent) {
+          return NextResponse.json({ error: 'Parent category not found' }, { status: 400 });
+        }
+        normalizedParentId = parsedParentId;
+      } else {
+        normalizedParentId = null;
       }
-      normalizedParentId = parsedParentId;
     }
 
     // Check for duplicate category name, excluding current category
@@ -339,7 +346,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
         name: name.trim(),
         slug: createSlug(name),
         description: description?.trim(),
-        parentId: normalizedParentId,
+        ...(shouldUpdateParentId ? { parentId: normalizedParentId } : {}),
       },
     });
 

--- a/app/api/category/all/route.ts
+++ b/app/api/category/all/route.ts
@@ -26,6 +26,10 @@ import { createSlug } from '@/shared/utils/create-slug';
  *         slug:
  *           type: string
  *           description: 카테고리 슬러그
+ *         parentId:
+ *           type: integer
+ *           nullable: true
+ *           description: 부모 카테고리 ID (루트면 null)
  *         createdAt:
  *           type: string
  *           format: date-time
@@ -36,6 +40,9 @@ import { createSlug } from '@/shared/utils/create-slug';
  *             posts:
  *               type: integer
  *               description: 해당 카테고리의 게시글 수
+ *             children:
+ *               type: integer
+ *               description: 자식 카테고리 수
  */
 
 /**
@@ -112,6 +119,10 @@ export async function GET(request: Request) {
  *               description:
  *                 type: string
  *                 description: 카테고리 설명
+ *               parentId:
+ *                 type: integer
+ *                 nullable: true
+ *                 description: 부모 카테고리 ID (루트면 null)
  *     responses:
  *       200:
  *         description: 카테고리 생성 성공
@@ -133,10 +144,24 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
     }
 
-    const { name, description } = await request.json();
+    const { name, description, parentId } = await request.json();
 
     if (!name?.trim()) {
       return NextResponse.json({ error: 'Category name is required' }, { status: 400 });
+    }
+
+    let normalizedParentId: number | null = null;
+    if (parentId != null && parentId !== '') {
+      const parsedParentId = Number(parentId);
+      if (Number.isNaN(parsedParentId)) {
+        return NextResponse.json({ error: 'Invalid parentId' }, { status: 400 });
+      }
+
+      const parent = await prisma.category.findUnique({ where: { id: parsedParentId } });
+      if (!parent) {
+        return NextResponse.json({ error: 'Parent category not found' }, { status: 400 });
+      }
+      normalizedParentId = parsedParentId;
     }
 
     // Check for duplicate category name
@@ -153,6 +178,7 @@ export async function POST(request: Request) {
         name: name.trim(),
         slug: createSlug(name),
         description: description?.trim(),
+        parentId: normalizedParentId,
       },
     });
 

--- a/app/api/category/all/route.ts
+++ b/app/api/category/all/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { parseCategoryParentId } from '@/entities/category';
 import prisma from '@/shared/lib/db';
 import { auth } from '@/shared/utils/auth';
 import { createSlug } from '@/shared/utils/create-slug';
@@ -56,7 +57,7 @@ import { createSlug } from '@/shared/utils/create-slug';
  *         name: includePostCount
  *         schema:
  *           type: boolean
- *         description: 각 카테고리의 게시글 수 포함 여부
+ *         description: 각 카테고리의 게시글 수(_count.posts) 포함 여부. 자식 수(_count.children)는 항상 포함됩니다.
  *     responses:
  *       200:
  *         description: 카테고리 목록 조회 성공
@@ -79,13 +80,12 @@ export async function GET(request: Request) {
         name: 'asc',
       },
       include: {
-        _count: includePostCount
-          ? {
-              select: {
-                posts: true,
-              },
-            }
-          : undefined,
+        _count: {
+          select: {
+            children: true,
+            ...(includePostCount ? { posts: true } : {}),
+          },
+        },
       },
     });
 
@@ -152,8 +152,8 @@ export async function POST(request: Request) {
 
     let normalizedParentId: number | null = null;
     if (parentId != null && parentId !== '') {
-      const parsedParentId = Number(parentId);
-      if (Number.isNaN(parsedParentId)) {
+      const parsedParentId = parseCategoryParentId(parentId);
+      if (parsedParentId == null) {
         return NextResponse.json({ error: 'Invalid parentId' }, { status: 400 });
       }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,17 +19,17 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
-// SEO 최적화를 위한 메타데이터
+// SEO 메타데이터
 export const metadata: Metadata = {
   title: {
-    default: '3D 블로그 - 개발자의 사이버펑크 공간',
-    template: '%s | 3D 블로그',
+    default: '3D Blog',
+    template: '%s | 3D Blog',
   },
-  description: 'React Three Fiber로 구현된 3D 인터랙티브 블로그 겸 포트폴리오.',
-  keywords: ['3D 블로그', 'React Three Fiber', 'Three.js', '개발', '프로그래밍', '사이버펑크', '인터랙티브'],
-  authors: [{ name: '3D 블로그 개발자' }],
-  creator: 'Ayaan',
-  publisher: 'Ayaan Company',
+  description: '웹 개발 기록을 남기는 블로그이자, Three.js 기반 3D 홈·포트폴리오입니다.',
+  keywords: ['블로그', '포트폴리오', '웹 개발', 'React', 'Next.js', 'Three.js', 'React Three Fiber'],
+  authors: [{ name: '3D Blog' }],
+  creator: '3D Blog',
+  publisher: '3D Blog',
 
   metadataBase: new URL(baseUrl),
   alternates: {
@@ -39,31 +39,30 @@ export const metadata: Metadata = {
     type: 'website',
     locale: 'ko_KR',
     url: baseUrl,
-    title: '3D 블로그 - 개발자의 사이버펑크 공간',
-    description:
-      'React Three Fiber로 구현된 3D 인터랙티브 블로그. 개발, 기술, 창작에 대한 이야기를 3D 공간에서 경험해보세요.',
-    siteName: '3D 블로그',
+    title: '3D Blog',
+    description: '웹 개발 기록과 Three.js로 만든 3D 홈·포트폴리오.',
+    siteName: '3D Blog',
     images: [
       {
         url: '/logo.png',
         width: 1200,
         height: 630,
-        alt: '3D 블로그 로고',
+        alt: '3D Blog 로고',
         type: 'image/png',
       },
       {
         url: '/logo.png',
         width: 800,
         height: 800,
-        alt: '3D 블로그 로고 (정사각형)',
+        alt: '3D Blog 로고',
         type: 'image/png',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: '3D 블로그 - 개발자의 사이버펑크 공간',
-    description: 'React Three Fiber로 구현된 3D 인터랙티브 블로그',
+    title: '3D Blog',
+    description: '웹 개발 기록과 Three.js로 만든 3D 홈·포트폴리오.',
     images: ['/logo.png', '/logo-square.png'],
   },
   robots: {

--- a/css.d.ts
+++ b/css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const content: string;
+  export default content;
+}

--- a/prisma/migrations/20260809060000_add_category_parent_id/migration.sql
+++ b/prisma/migrations/20260809060000_add_category_parent_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN "parentId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,12 +22,15 @@ model User {
 }
 
 model Category {
-  id          Int      @id @default(autoincrement())
-  name        String   @unique
-  slug        String   @unique @default("")
+  id          Int        @id @default(autoincrement())
+  name        String     @unique
+  slug        String     @unique @default("")
   description String?
+  parentId    Int?
+  parent      Category?  @relation("CategoryToCategory", fields: [parentId], references: [id])
+  children    Category[] @relation("CategoryToCategory")
   posts       Post[]
-  createdAt   DateTime @default(now())
+  createdAt   DateTime   @default(now())
 }
 
 model Tag {

--- a/src/entities/category/index.ts
+++ b/src/entities/category/index.ts
@@ -1,3 +1,4 @@
 export * from './model';
 export * from './lib/build-category-tree';
+export * from './lib/parse-category-parent-id';
 export * from './lib/to-category-list-item';

--- a/src/entities/category/index.ts
+++ b/src/entities/category/index.ts
@@ -1,0 +1,3 @@
+export * from './model';
+export * from './lib/build-category-tree';
+export * from './lib/to-category-list-item';

--- a/src/entities/category/lib/build-category-tree.ts
+++ b/src/entities/category/lib/build-category-tree.ts
@@ -11,7 +11,7 @@ type CategoryLike = {
   parentId?: number | null;
 };
 
-/** 플랫 카테고리 목록을 parentId 기준 트리로 변환 */
+/** 플랫 카테고리 목록을 parentId 기준 트리로 변환 (순환 parent는 루트로 분리) */
 export const buildCategoryTree = <T extends CategoryLike>(categories: T[]): CategoryTreeNode<T>[] => {
   const nodes = new Map<number, CategoryTreeNode<T>>();
 
@@ -20,14 +20,34 @@ export const buildCategoryTree = <T extends CategoryLike>(categories: T[]): Cate
   }
 
   const roots: CategoryTreeNode<T>[] = [];
+  const parentOf = new Map<number, number>();
+
+  const wouldCreateCycle = (childId: number, parentId: number): boolean => {
+    let current: number | undefined = parentId;
+    const visited = new Set<number>();
+
+    while (current != null) {
+      if (current === childId) return true;
+      if (visited.has(current)) return true;
+      visited.add(current);
+      current = parentOf.get(current);
+    }
+
+    return false;
+  };
 
   for (const category of categories) {
     const node = nodes.get(category.id);
     if (!node) continue;
 
     const parentId = category.parentId ?? null;
-    if (parentId != null && nodes.has(parentId)) {
+    if (
+      parentId != null &&
+      nodes.has(parentId) &&
+      !wouldCreateCycle(category.id, parentId)
+    ) {
       nodes.get(parentId)?.children.push(node);
+      parentOf.set(category.id, parentId);
       continue;
     }
 
@@ -71,9 +91,11 @@ export const collectAncestorIds = <T extends CategoryLike>(categories: T[], acti
   if (activeId == null) return ancestors;
 
   const byId = new Map(categories.map((category) => [category.id, category]));
+  const visited = new Set<number>();
   let current = byId.get(activeId);
 
-  while (current?.parentId != null) {
+  while (current?.parentId != null && !visited.has(current.id)) {
+    visited.add(current.id);
     ancestors.add(current.parentId);
     current = byId.get(current.parentId);
   }

--- a/src/entities/category/lib/build-category-tree.ts
+++ b/src/entities/category/lib/build-category-tree.ts
@@ -1,0 +1,100 @@
+import type { Category } from '@prisma/client';
+
+export type CategoryTreeNode<
+  T extends { id: number; parentId?: number | null } = Category & { parentId?: number | null },
+> = T & {
+  children: CategoryTreeNode<T>[];
+};
+
+type CategoryLike = {
+  id: number;
+  parentId?: number | null;
+};
+
+/** 플랫 카테고리 목록을 parentId 기준 트리로 변환 */
+export const buildCategoryTree = <T extends CategoryLike>(categories: T[]): CategoryTreeNode<T>[] => {
+  const nodes = new Map<number, CategoryTreeNode<T>>();
+
+  for (const category of categories) {
+    nodes.set(category.id, { ...category, children: [] });
+  }
+
+  const roots: CategoryTreeNode<T>[] = [];
+
+  for (const category of categories) {
+    const node = nodes.get(category.id);
+    if (!node) continue;
+
+    const parentId = category.parentId ?? null;
+    if (parentId != null && nodes.has(parentId)) {
+      nodes.get(parentId)?.children.push(node);
+      continue;
+    }
+
+    roots.push(node);
+  }
+
+  return roots;
+};
+
+/** 선택 불가한 자기 자신 + 자손 id 집합 */
+export const collectDescendantIds = <T extends CategoryLike>(categories: T[], rootId: number): Set<number> => {
+  const childrenByParent = new Map<number, number[]>();
+
+  for (const category of categories) {
+    const parentId = category.parentId ?? null;
+    if (parentId == null) continue;
+    const list = childrenByParent.get(parentId) ?? [];
+    list.push(category.id);
+    childrenByParent.set(parentId, list);
+  }
+
+  const blocked = new Set<number>([rootId]);
+  const stack = [rootId];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) continue;
+    for (const childId of childrenByParent.get(current) ?? []) {
+      if (blocked.has(childId)) continue;
+      blocked.add(childId);
+      stack.push(childId);
+    }
+  }
+
+  return blocked;
+};
+
+/** 활성 slug의 조상 id들을 열어두기 위해 수집 */
+export const collectAncestorIds = <T extends CategoryLike>(categories: T[], activeId: number | null): Set<number> => {
+  const ancestors = new Set<number>();
+  if (activeId == null) return ancestors;
+
+  const byId = new Map(categories.map((category) => [category.id, category]));
+  let current = byId.get(activeId);
+
+  while (current?.parentId != null) {
+    ancestors.add(current.parentId);
+    current = byId.get(current.parentId);
+  }
+
+  return ancestors;
+};
+
+/** Select 등에서 들여쓰기 라벨용 플랫 목록 */
+export const flattenCategoryTree = <T extends CategoryLike>(
+  tree: CategoryTreeNode<T>[],
+  depth = 0,
+): Array<T & { depth: number }> => {
+  const result: Array<T & { depth: number }> = [];
+
+  for (const node of tree) {
+    const { children, ...rest } = node;
+    result.push({ ...(rest as unknown as T), depth });
+    if (children.length > 0) {
+      result.push(...flattenCategoryTree(children, depth + 1));
+    }
+  }
+
+  return result;
+};

--- a/src/entities/category/lib/parse-category-parent-id.ts
+++ b/src/entities/category/lib/parse-category-parent-id.ts
@@ -1,0 +1,11 @@
+/** parentId 본문 값을 양의 정수로 파싱. 유효하지 않으면 null */
+export const parseCategoryParentId = (parentId: unknown): number | null => {
+  const parsed =
+    typeof parentId === 'number' || typeof parentId === 'string' ? Number(parentId) : Number.NaN;
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+};

--- a/src/entities/category/lib/to-category-list-item.ts
+++ b/src/entities/category/lib/to-category-list-item.ts
@@ -1,0 +1,17 @@
+import type { CategoryListItem, CategoryResponse } from '../model';
+
+type CategoryApiItem = CategoryResponse extends Array<infer Item> ? Item : never;
+
+/** OpenAPI Category 응답을 사이드바/관리자용 CategoryListItem으로 정규화 */
+export const toCategoryListItem = (category: CategoryApiItem): CategoryListItem => ({
+  id: category.id,
+  name: category.name,
+  slug: category.slug ?? '',
+  description: category.description ?? null,
+  parentId: category.parentId ?? null,
+  createdAt: category.createdAt,
+  _count: category._count,
+});
+
+export const toCategoryListItems = (categories: CategoryResponse | undefined | null): CategoryListItem[] =>
+  (categories ?? []).map(toCategoryListItem);

--- a/src/entities/category/model.ts
+++ b/src/entities/category/model.ts
@@ -5,6 +5,20 @@ export type Category = {
   name: string;
   slug: string;
   description?: string;
+  parentId?: number | null;
+};
+
+export type CategoryListItem = {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string | null;
+  parentId?: number | null;
+  createdAt?: string;
+  _count?: {
+    posts?: number;
+    children?: number;
+  };
 };
 
 export type CategoryResponse = ApiResponse<'/api/category/all', 'get'>;

--- a/src/features/admin/post/ui/category-selector.tsx
+++ b/src/features/admin/post/ui/category-selector.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { useState, useEffect, forwardRef, useImperativeHandle, useMemo } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn-ui/components/ui/select';
 import { useCategories } from '@/features/category/model';
+import { buildCategoryTree, flattenCategoryTree } from '@/entities/category/lib/build-category-tree';
 
 export interface CategorySelectorRef {
   getSelectedCategoryId: () => string;
@@ -17,6 +18,15 @@ export const CategorySelector = forwardRef<CategorySelectorRef, CategorySelector
   ({ initialCategoryId = '' }, ref) => {
     const [selectedCategoryId, setSelectedCategoryId] = useState(initialCategoryId);
     const { data: categories } = useCategories();
+
+    const flatOptions = useMemo(() => {
+      const list = (categories ?? []).map((category) => ({
+        id: category.id,
+        parentId: category.parentId ?? null,
+        name: category.name,
+      }));
+      return flattenCategoryTree(buildCategoryTree(list));
+    }, [categories]);
 
     // 초기값이 변경되면 내부 상태도 업데이트
     useEffect(() => {
@@ -35,27 +45,29 @@ export const CategorySelector = forwardRef<CategorySelectorRef, CategorySelector
 
     return (
       <div className='space-y-2'>
-        <label className='text-xs font-medium text-muted-foreground flex items-center gap-1'>
-          <span className='w-1.5 h-1.5 bg-blue-400 rounded-full'></span>
+        <span className='text-xs font-medium text-muted-foreground flex items-center gap-1'>
+          <span className='w-1.5 h-1.5 bg-blue-400 rounded-full' />
           카테고리
-        </label>
+        </span>
         <Select value={selectedCategoryId} onValueChange={handleCategoryChange}>
-          <SelectTrigger className='h-9 bg-muted/10 border-muted-foreground/20 text-foreground hover:bg-muted/20 transition-colors text-sm'>
+          <SelectTrigger className='h-9 w-full border-white/30 bg-white/10 text-foreground backdrop-blur-md hover:bg-white/15 transition-colors text-sm'>
             <SelectValue placeholder='카테고리 선택' />
           </SelectTrigger>
-          <SelectContent className='bg-muted/95 backdrop-blur-sm border-muted-foreground/20'>
-            {categories?.map((category) => (
-              <SelectItem 
-                key={category.id} 
+          <SelectContent className='z-[100] overflow-hidden rounded-xl border border-white/30 bg-gradient-to-br from-white/20 via-[#1b2133]/85 to-[#151a28]/90 text-white shadow-[0_0_30px_rgba(255,255,255,0.18)] backdrop-blur-2xl'>
+            {flatOptions.map((category) => (
+              <SelectItem
+                key={category.id}
                 value={category.id.toString()}
-                className='hover:bg-muted/50 focus:bg-muted/50 text-sm'
+                className='rounded-md text-sm focus:bg-white/20 focus:text-white data-[highlighted]:bg-white/20 data-[highlighted]:text-white'
               >
-                {category.name}
+                {`${'—'.repeat(category.depth)}${category.depth > 0 ? ' ' : ''}${category.name}`}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
     );
-  }
+  },
 );
+
+CategorySelector.displayName = 'CategorySelector';

--- a/src/features/category/api/category-api.ts
+++ b/src/features/category/api/category-api.ts
@@ -6,13 +6,17 @@ import { fetcher } from '@/shared/api';
 export const getCategories = fetcher({ url: '/api/category/all', method: 'get', query: { includePostCount: false } });
 
 // 새 카테고리 생성
-export const createCategory = async ({ name, description }: CategoryFormSchema) => {
+export const createCategory = async ({ name, description, parentId }: CategoryFormSchema) => {
   const response = await fetch('/api/category/all', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ name, description }),
+    body: JSON.stringify({
+      name,
+      description,
+      parentId: parentId ?? null,
+    }),
   });
 
   if (!response.ok) {
@@ -34,6 +38,7 @@ export const getCategoryPosts = (slug: string, page = 1, limit = 10) =>
 type CategoryInput = {
   name: string;
   description?: string;
+  parentId?: number | null;
 };
 
 // Update category
@@ -43,7 +48,10 @@ export async function updateCategory(id: string, data: CategoryInput): Promise<C
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(data),
+    body: JSON.stringify({
+      ...data,
+      parentId: data.parentId ?? null,
+    }),
   });
 
   if (!response.ok) {

--- a/src/features/category/model/category-schema.ts
+++ b/src/features/category/model/category-schema.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 export const categoryFormSchema = z.object({
   name: z.string().min(1, { message: '카테고리 이름을 입력해주세요.' }),
   description: z.string().optional(),
+  parentId: z.union([z.number().int().positive(), z.null()]).optional(),
 });
 
 export type CategoryFormSchema = z.infer<typeof categoryFormSchema>;

--- a/src/features/category/ui/category-form.tsx
+++ b/src/features/category/ui/category-form.tsx
@@ -1,12 +1,19 @@
 'use client';
 
 import type { Category } from '@/entities/category/model';
+import {
+  buildCategoryTree,
+  collectDescendantIds,
+  flattenCategoryTree,
+} from '@/entities/category/lib/build-category-tree';
+import { useCategories } from '@/features/category/model';
 import { Button } from '@/shadcn-ui/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/shadcn-ui/components/ui/form';
 import { Input } from '@/shadcn-ui/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shadcn-ui/components/ui/select';
 import { Textarea } from '@/shadcn-ui/components/ui/textarea';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { type CategoryFormSchema, categoryFormSchema } from '../model/category-schema';
 
@@ -15,21 +22,41 @@ type CategoryFormProps = {
   initialData?: Category;
 };
 
+const ROOT_PARENT_VALUE = '__root__';
+
 const CategoryForm = ({ onSubmit, initialData }: CategoryFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const { data: categories } = useCategories();
 
   const form = useForm<CategoryFormSchema>({
     resolver: zodResolver(categoryFormSchema),
-    defaultValues: initialData || {
-      name: '',
-      description: '',
+    defaultValues: {
+      name: initialData?.name ?? '',
+      description: initialData?.description ?? '',
+      parentId: initialData?.parentId ?? null,
     },
   });
+
+  const parentOptions = useMemo(() => {
+    const list = (categories ?? []).map((category) => ({
+      id: category.id,
+      parentId: category.parentId ?? null,
+      name: category.name,
+    }));
+
+    const currentId = initialData?.id ? Number(initialData.id) : null;
+    const blocked = currentId != null ? collectDescendantIds(list, currentId) : new Set<number>();
+    const tree = buildCategoryTree(list.filter((category) => !blocked.has(category.id)));
+    return flattenCategoryTree(tree);
+  }, [categories, initialData?.id]);
 
   const handleFormSubmit = async (data: CategoryFormSchema) => {
     setIsLoading(true);
     try {
-      await onSubmit(data);
+      await onSubmit({
+        ...data,
+        parentId: data.parentId ?? null,
+      });
     } catch (error) {
       console.error('Failed to submit category:', error);
     } finally {
@@ -72,6 +99,47 @@ const CategoryForm = ({ onSubmit, initialData }: CategoryFormProps) => {
               <FormControl>
                 <Textarea placeholder='카테고리에 대한 간단한 설명을 입력하세요.' {...field} />
               </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name='parentId'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>부모 카테고리</FormLabel>
+              <Select
+                value={field.value == null ? ROOT_PARENT_VALUE : String(field.value)}
+                onValueChange={(value) => {
+                  field.onChange(value === ROOT_PARENT_VALUE ? null : Number(value));
+                }}
+              >
+                <FormControl>
+                  <SelectTrigger className='w-full border-white/30 bg-white/10 text-white backdrop-blur-md hover:bg-white/15'>
+                    <SelectValue placeholder='루트 카테고리' />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent
+                  className='z-[100] overflow-hidden rounded-xl border border-white/30 bg-gradient-to-br from-white/20 via-[#1b2133]/85 to-[#151a28]/90 text-white shadow-[0_0_30px_rgba(255,255,255,0.18)] backdrop-blur-2xl'
+                >
+                  <SelectItem
+                    value={ROOT_PARENT_VALUE}
+                    className='rounded-md focus:bg-white/20 focus:text-white data-[highlighted]:bg-white/20 data-[highlighted]:text-white'
+                  >
+                    없음 (루트)
+                  </SelectItem>
+                  {parentOptions.map((category) => (
+                    <SelectItem
+                      key={category.id}
+                      value={String(category.id)}
+                      className='rounded-md focus:bg-white/20 focus:text-white data-[highlighted]:bg-white/20 data-[highlighted]:text-white'
+                    >
+                      {`${'—'.repeat(category.depth)}${category.depth > 0 ? ' ' : ''}${category.name}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormMessage />
             </FormItem>
           )}

--- a/src/features/category/ui/category-form.tsx
+++ b/src/features/category/ui/category-form.tsx
@@ -52,13 +52,16 @@ const CategoryForm = ({ onSubmit, initialData }: CategoryFormProps) => {
 
   const handleFormSubmit = async (data: CategoryFormSchema) => {
     setIsLoading(true);
+    form.clearErrors('root');
     try {
       await onSubmit({
         ...data,
         parentId: data.parentId ?? null,
       });
     } catch (error) {
-      console.error('Failed to submit category:', error);
+      form.setError('root', {
+        message: error instanceof Error ? error.message : '카테고리 저장에 실패했습니다.',
+      });
     } finally {
       setIsLoading(false);
     }
@@ -77,6 +80,11 @@ const CategoryForm = ({ onSubmit, initialData }: CategoryFormProps) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)} className='space-y-8'>
+        {form.formState.errors.root?.message && (
+          <p className='rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm text-red-200' role='alert'>
+            {form.formState.errors.root.message}
+          </p>
+        )}
         <FormField
           control={form.control}
           name='name'

--- a/src/shared/api/openapi-types.ts
+++ b/src/shared/api/openapi-types.ts
@@ -4,2309 +4,2273 @@
  */
 
 export interface paths {
-  '/api/category/{slug}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get a single category with its posts */
-    get: {
-      parameters: {
-        query?: {
-          /** @description Search keyword for post title or content */
-          search?: string;
-          /** @description Page number for pagination */
-          page?: number;
-          /** @description Number of items per page */
-          limit?: number;
+    "/api/category/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        header?: never;
-        path: {
-          /** @description Category slug */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Returns category with posts and pagination info */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              name?: string;
-              slug?: string;
-              description?: string | null;
-              /** Format: date-time */
-              createdAt?: string;
-              posts?: {
-                id?: number;
-                title?: string;
-                content?: string;
-                /** Format: date-time */
-                createdAt?: string;
-                /** Format: date-time */
-                updatedAt?: string;
-                author?: {
-                  id?: number;
-                  name?: string;
+        /** Get a single category with its posts */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Search keyword for post title or content */
+                    search?: string;
+                    /** @description Page number for pagination */
+                    page?: number;
+                    /** @description Number of items per page */
+                    limit?: number;
                 };
-                _count?: {
-                  comments?: number;
-                  likes?: number;
+                header?: never;
+                path: {
+                    /** @description Category slug */
+                    slug: string;
                 };
-              }[];
-              _count?: {
-                posts?: number;
-              };
-              pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
+                cookie?: never;
             };
-          };
-        };
-        /** @description Category not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Internal server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    /** Delete a category */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Category ID */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Category deleted successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              success?: boolean;
-            };
-          };
-        };
-        /** @description Cannot delete category with posts */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Cannot delete category that contains posts */
-              error?: string;
-            };
-          };
-        };
-        /** @description Forbidden - Admin access required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Category not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Internal server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** Update a category */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Category ID */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            name: string;
-            description?: string | null;
-          };
-        };
-      };
-      responses: {
-        /** @description Category updated successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              name?: string;
-              slug?: string;
-              description?: string | null;
-              /** Format: date-time */
-              createdAt?: string;
-            };
-          };
-        };
-        /** @description Invalid input or duplicate category name */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Forbidden - Admin access required */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Forbidden: Admin access required */
-              error?: string;
-            };
-          };
-        };
-        /** @description Internal server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/api/category/all': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 카테고리 목록 조회
-     * @description 모든 카테고리를 조회합니다.
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description 각 카테고리의 게시글 수 포함 여부 */
-          includePostCount?: boolean;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 카테고리 목록 조회 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Category'][];
-          };
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /**
-     * 새 카테고리 생성
-     * @description 새로운 카테고리를 생성합니다. (관리자 전용)
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 카테고리 이름 */
-            name: string;
-            /** @description 카테고리 설명 */
-            description?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description 카테고리 생성 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Category'];
-          };
-        };
-        /** @description 잘못된 요청 (중복된 이름 등) */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 권한 없음 */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/comments/{postId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 특정 게시물의 댓글 목록 조회
-     * @description 게시물 ID에 해당하는 모든 댓글과 대댓글을 계층 구조로 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 ID */
-          postId: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 댓글 목록 반환 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              content?: string;
-              createdAt?: string;
-              author?: {
-                name?: string;
-                id?: number;
-                parentId?: number;
-              };
-              likes?: number;
-              dislikes?: number;
-              replies?: {
-                id?: number;
-                content?: string;
-                createdAt?: string;
-                author?: {
-                  name?: string;
-                  id?: number;
-                  parentId?: number;
+            requestBody?: never;
+            responses: {
+                /** @description Returns category with posts and pagination info */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            name?: string;
+                            slug?: string;
+                            description?: string | null;
+                            /** Format: date-time */
+                            createdAt?: string;
+                            posts?: {
+                                id?: number;
+                                title?: string;
+                                content?: string;
+                                /** Format: date-time */
+                                createdAt?: string;
+                                /** Format: date-time */
+                                updatedAt?: string;
+                                author?: {
+                                    id?: number;
+                                    name?: string;
+                                };
+                                _count?: {
+                                    comments?: number;
+                                    likes?: number;
+                                };
+                            }[];
+                            _count?: {
+                                posts?: number;
+                            };
+                            pagination?: {
+                                page?: number;
+                                limit?: number;
+                                total?: number;
+                                totalPages?: number;
+                            };
+                        };
+                    };
                 };
-                likes?: number;
-                dislikes?: number;
-              }[];
-            }[];
-          };
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/comments/individual/{commentId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /**
-     * 댓글 수정
-     * @description 특정 댓글의 내용을 수정합니다. 작성자 또는 관리자만 수정할 수 있습니다.
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 댓글 ID */
-          commentId: number;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 수정할 댓글 내용 */
-            content: string;
-          };
-        };
-      };
-      responses: {
-        /** @description 댓글 수정 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              content?: string;
-              updatedAt?: string;
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 인증되지 않은 사용자 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 권한 없음 (작성자가 아님) */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 댓글을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    /**
-     * 댓글 삭제
-     * @description 특정 댓글을 삭제합니다. 대댓글이 있는 댓글을 삭제하면 대댓글도 함께 삭제됩니다. 작성자 또는 관리자만 삭제할 수 있습니다.
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 댓글 ID */
-          commentId: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 댓글 삭제 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 인증되지 않은 사용자 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 권한 없음 (작성자가 아님) */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 댓글을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/comments/like/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 댓글 좋아요/싫어요 수 조회
-     * @description 특정 댓글의 좋아요/싫어요 수와 사용자의 반응 상태를 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description 사용자 ID (반응 상태 확인용) */
-          userId?: number;
-        };
-        header?: never;
-        path: {
-          /** @description 댓글 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 댓글 반응 정보 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              likes?: number;
-              dislikes?: number;
-              /** @enum {string} */
-              userReaction?: 'LIKE' | 'DISLIKE' | null;
-            };
-          };
-        };
-        /** @description 댓글을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /**
-     * 댓글 좋아요/싫어요 토글
-     * @description 댓글에 좋아요/싫어요를 추가하거나 제거합니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 댓글 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            userId: number;
-            /** @enum {string} */
-            type: 'LIKE' | 'DISLIKE';
-          };
-        };
-      };
-      responses: {
-        /** @description 댓글 반응 토글 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @enum {string} */
-              userReaction?: 'LIKE' | 'DISLIKE' | null;
-              likes?: number;
-              dislikes?: number;
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 댓글을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/comments': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * 댓글 또는 대댓글 생성
-     * @description 새로운 댓글을 생성합니다. parentId가 있으면 대댓글, 없으면 댓글입니다. 인증된 사용자만 사용 가능합니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 댓글 내용 */
-            content: string;
-            /** @description 게시물 ID */
-            postId: number;
-            /** @description 부모 댓글 ID (대댓글인 경우) */
-            parentId?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description 댓글 생성 성공 */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              content?: string;
-              createdAt?: string;
-              author?: {
-                name?: string;
-              };
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 인증되지 않은 사용자 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/post/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 특정 게시물 조회
-     * @description 게시물 ID를 기반으로 상세 정보를 조회합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 게시물 조회 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              title?: string;
-              content?: string;
-              author?: {
-                id?: number;
-                name?: string;
-                email?: string;
-              };
-              category?: Record<string, never>;
-              tags?: unknown[];
-              comments?: unknown[];
-              likes?: unknown[];
-            };
-          };
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /**
-     * 게시물 수정
-     * @description 특정 게시물의 정보를 수정합니다.
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 게시물 제목 */
-            title?: string;
-            /** @description 게시물 내용 */
-            content?: string;
-            /** @description 카테고리 ID */
-            categoryId?: number;
-            /** @description 태그 ID 배열 */
-            tags?: number[];
-          };
-        };
-      };
-      responses: {
-        /** @description 게시물 수정 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    /**
-     * 게시물 삭제
-     * @description 특정 게시물과 관련된 모든 데이터(댓글, 좋아요)를 삭제합니다.
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 게시물 삭제 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Post deleted successfully */
-              message?: string;
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/posts/{slug}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 특정 게시물 조회
-     * @description 게시물 slug를 기반으로 상세 정보를 조회합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 slug */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 게시물 조회 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              slug?: string;
-              title?: string;
-              content?: string;
-              /** Format: date-time */
-              createdAt?: string;
-              /** Format: date-time */
-              updatedAt?: string;
-              views?: number;
-              author?: {
-                id?: number;
-                name?: string;
-                email?: string;
-              };
-              category?: {
-                id?: number;
-                name?: string;
-                slug?: string;
-              };
-              tags?: {
-                id?: number;
-                name?: string;
-                slug?: string;
-              }[];
-              comments?: {
-                id?: number;
-                content?: string;
-                /** Format: date-time */
-                createdAt?: string;
-                author?: {
-                  id?: number;
-                  name?: string;
+                /** @description Category not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
-                replies?: {
-                  id?: number;
-                  content?: string;
-                  /** Format: date-time */
-                  createdAt?: string;
-                  author?: {
-                    id?: number;
-                    name?: string;
-                  };
-                }[];
-              }[];
-              likes?: {
-                id?: number;
-                user?: {
-                  id?: number;
-                  name?: string;
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
-              }[];
             };
-          };
         };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /**
-     * 게시물 수정
-     * @description 특정 게시물의 정보를 수정합니다.
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 slug */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 게시물 제목 */
-            title?: string;
-            /** @description 게시물 내용 */
-            content?: string;
-            /** @description 카테고리 ID */
-            categoryId?: number;
-            /** @description 태그 ID 배열 */
-            tags?: number[];
-          };
-        };
-      };
-      responses: {
-        /** @description 게시물 수정 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    /**
-     * 게시물 삭제
-     * @description 특정 게시물과 관련된 모든 데이터(댓글, 좋아요)를 삭제합니다.
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 게시물 slug */
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 게시물 삭제 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Post deleted successfully */
-              message?: string;
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 게시물을 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/posts/{slug}/view': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * 게시글 조회수 증가
-     * @description 게시글 조회수를 증가시킵니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          slug: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 조회수 증가 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              ok?: boolean;
-              views?: number;
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/posts/like/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 포스트 좋아요 수 조회
-     * @description 특정 포스트의 좋아요 수와 사용자의 좋아요 여부를 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description 사용자 ID (좋아요 여부 확인용) */
-          userId?: number;
-        };
-        header?: never;
-        path: {
-          /** @description 포스트 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 좋아요 정보 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              count?: number;
-              isLiked?: boolean;
-            };
-          };
-        };
-        /** @description 포스트를 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /**
-     * 포스트 좋아요 토글
-     * @description 포스트에 좋아요를 추가하거나 제거합니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 포스트 ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            userId: number;
-          };
-        };
-      };
-      responses: {
-        /** @description 좋아요 토글 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              isLiked?: boolean;
-              count?: number;
-            };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 포스트를 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/posts': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 게시물 목록 조회
-     * @description 검색어와 페이지네이션 옵션을 이용해 게시물 목록을 가져옵니다.
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description 게시물 검색어 (title, content) */
-          search?: string;
-          /** @description 카테고리 slug로 필터링 */
-          category?: string;
-          /** @description 태그 ID들을 쉼표로 구분하여 필터링 */
-          tags?: string;
-          /** @description 페이지 번호 */
-          page?: number;
-          /** @description 한 페이지 당 아이템 개수 */
-          limit?: number;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 게시물 목록과 메타데이터 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data?: {
-                id?: number;
-                title?: string;
-                content?: string;
-                /** Format: date-time */
-                createdAt?: string;
-                category?: {
-                  name?: string;
-                  slug?: string;
+        put?: never;
+        post?: never;
+        /** Delete a category */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Category ID */
+                    slug: string;
                 };
-                author?: {
-                  name?: string;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Category deleted successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success?: boolean;
+                        };
+                    };
                 };
-                tags?: {
-                  id?: number;
-                  name?: string;
-                }[];
-              }[];
-              meta?: {
-                pagination?: {
-                  currentPage?: number;
-                  totalPages?: number;
-                  totalItems?: number;
-                  itemsPerPage?: number;
-                  hasNextPage?: boolean;
-                  hasPrevPage?: boolean;
+                /** @description Cannot delete category with posts */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Cannot delete category that contains posts */
+                            error?: string;
+                        };
+                    };
                 };
-              };
+                /** @description Forbidden - Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Category not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description 잘못된 페이지네이션 파라미터 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /**
-     * 게시물 생성
-     * @description 새로운 게시물을 생성합니다. 관리자 또는 인증된 사용자만 접근 가능합니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 게시물 제목 */
-            title: string;
-            /** @description 게시물 내용 */
-            content: string;
-            /** @description 카테고리 ID */
-            categoryId: number;
-            /** @description 태그 ID 배열 (선택사항) */
-            tags?: number[];
-          };
-        };
-      };
-      responses: {
-        /** @description 게시물이 성공적으로 생성됨 */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              title?: string;
-              content?: string;
-              authorId?: number;
-              categoryId?: number;
-              /** Format: date-time */
-              createdAt?: string;
-              /** Format: date-time */
-              updatedAt?: string;
+        options?: never;
+        head?: never;
+        /** Update a category */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Category ID */
+                    slug: string;
+                };
+                cookie?: never;
             };
-          };
-        };
-        /** @description 잘못된 요청 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              error?: string;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        description?: string | null;
+                        /** @description 부모 카테고리 ID (루트면 null) */
+                        parentId?: number | null;
+                    };
+                };
             };
-          };
-        };
-        /** @description 인증되지 않은 사용자 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 권한 없음 */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              error?: string;
+            responses: {
+                /** @description Category updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            name?: string;
+                            slug?: string;
+                            description?: string | null;
+                            /** Format: date-time */
+                            createdAt?: string;
+                        };
+                    };
+                };
+                /** @description Invalid input or duplicate category name */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden - Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Forbidden: Admin access required */
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-      };
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/users': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 모든 사용자 목록 조회
-     * @description 모든 사용자 목록을 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 사용자 목록 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['User'][];
-          };
+    "/api/category/all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** Create a new user (User Registration) */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description User's full name */
-            name: string;
-            /**
-             * Format: email
-             * @description User's email address
-             * @example user@example.com
-             */
-            email: string;
-            /** @description User's password */
-            password: string;
-          };
-        };
-      };
-      responses: {
-        /** @description User successfully created */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              name?: string;
-              email?: string;
-              /**
-               * @default USER
-               * @enum {string}
-               */
-              role: 'USER' | 'ADMIN';
-              /** Format: date-time */
-              createdAt?: string;
+        /**
+         * 카테고리 목록 조회
+         * @description 모든 카테고리를 조회합니다.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 각 카테고리의 게시글 수 포함 여부 */
+                    includePostCount?: boolean;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Invalid email or password */
-              error?: string;
+            requestBody?: never;
+            responses: {
+                /** @description 카테고리 목록 조회 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Category"][];
+                    };
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description User already exists */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Email already in use */
-              error?: string;
+        put?: never;
+        /**
+         * 새 카테고리 생성
+         * @description 새로운 카테고리를 생성합니다. (관리자 전용)
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-        /** @description Internal server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Internal server error */
-              error?: string;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 카테고리 이름 */
+                        name: string;
+                        /** @description 카테고리 설명 */
+                        description?: string;
+                        /** @description 부모 카테고리 ID (루트면 null) */
+                        parentId?: number | null;
+                    };
+                };
             };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/stats': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 사이트 통계 조회
-     * @description 게시물, 사용자, 댓글, 조회수의 월별 통계를 조회합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 통계 데이터 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              posts?: {
-                /** @description 전체 게시물 수 */
-                total?: number;
-                /** @description 이번달 게시물 수 */
-                thisMonth?: number;
-                /** @description 저번달 게시물 수 */
-                lastMonth?: number;
-              };
-              users?: {
-                /** @description 전체 사용자 수 */
-                total?: number;
-                /** @description 이번달 가입자 수 */
-                thisMonth?: number;
-                /** @description 저번달 가입자 수 */
-                lastMonth?: number;
-              };
-              comments?: {
-                /** @description 전체 댓글 수 */
-                total?: number;
-                /** @description 이번달 댓글 수 */
-                thisMonth?: number;
-                /** @description 저번달 댓글 수 */
-                lastMonth?: number;
-              };
-              views?: {
-                /** @description 전체 조회수 */
-                total?: number;
-                /** @description 이번달 조회수 */
-                thisMonth?: number;
-                /** @description 저번달 조회수 */
-                lastMonth?: number;
-              };
+            responses: {
+                /** @description 카테고리 생성 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Category"];
+                    };
+                };
+                /** @description 잘못된 요청 (중복된 이름 등) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 권한 없음 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Failed to fetch stats */
-              error?: string;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/comments/{postId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 특정 게시물의 댓글 목록 조회
+         * @description 게시물 ID에 해당하는 모든 댓글과 대댓글을 계층 구조로 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 ID */
+                    postId: number;
+                };
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/summarize': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * 블로그 포스트 요약 생성
-     * @description AI를 사용하여 블로그 포스트의 내용을 간결하게 요약합니다
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /**
-             * @description 요약할 블로그 포스트 내용
-             * @example 이 글에서는 React와 Next.js를 사용한 웹 개발에 대해 다룹니다...
-             */
-            content: string;
-            /**
-             * @description 블로그 포스트 제목
-             * @example React와 Next.js로 현대적인 웹 애플리케이션 구축하기
-             */
-            title: string;
-          };
-        };
-      };
-      responses: {
-        /** @description 요약 생성 성공 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /**
-               * @description 생성된 요약 텍스트
-               * @example React와 Next.js를 활용한 웹 개발 방법론과 실제 구현 과정을 다룬 글입니다.
-               */
-              summary?: string;
+            requestBody?: never;
+            responses: {
+                /** @description 댓글 목록 반환 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            content?: string;
+                            createdAt?: string;
+                            author?: {
+                                name?: string;
+                                id?: number;
+                                parentId?: number;
+                            };
+                            likes?: number;
+                            dislikes?: number;
+                            replies?: {
+                                id?: number;
+                                content?: string;
+                                createdAt?: string;
+                                author?: {
+                                    name?: string;
+                                    id?: number;
+                                    parentId?: number;
+                                };
+                                likes?: number;
+                                dislikes?: number;
+                            }[];
+                        }[];
+                    };
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description 필수 필드 누락 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example 콘텐츠와 제목이 필요합니다. */
-              error?: string;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/comments/individual/{commentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * 댓글 수정
+         * @description 특정 댓글의 내용을 수정합니다. 작성자 또는 관리자만 수정할 수 있습니다.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 댓글 ID */
+                    commentId: number;
+                };
+                cookie?: never;
             };
-          };
-        };
-        /** @description 서버 오류 또는 AI 요약 생성 실패 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example 요약 생성에 실패했습니다. */
-              error?: string;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 수정할 댓글 내용 */
+                        content: string;
+                    };
+                };
             };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/tags/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get a specific tag
-     * @description Retrieve a tag by its ID with related posts
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Tag ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Tag retrieved successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Tag not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /**
-     * Update a tag
-     * @description Update a tag's name by its ID
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Tag ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            name: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Tag updated successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Name already in use */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Tag not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    /**
-     * Delete a tag
-     * @description Delete a tag by its ID
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Tag ID */
-          id: number;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Tag deleted successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Tag not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/tags': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get all tags
-     * @description Retrieve a list of all tags with post counts
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description A list of tags */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              id?: number;
-              name?: string;
-              /** Format: date-time */
-              createdAt?: string;
-              count?: {
-                posts?: number;
-              };
-            }[];
-          };
-        };
-        /** @description Server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              error?: string;
+            responses: {
+                /** @description 댓글 수정 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            content?: string;
+                            updatedAt?: string;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 인증되지 않은 사용자 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 권한 없음 (작성자가 아님) */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 댓글을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-      };
-    };
-    put?: never;
-    /**
-     * Create a new tag
-     * @description Create a new tag in the system
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @example JavaScript */
-            name: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Tag created successfully */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example 1 */
-              id?: number;
-              /** @example JavaScript */
-              name?: string;
-              /** Format: date-time */
-              createdAt?: string;
+        post?: never;
+        /**
+         * 댓글 삭제
+         * @description 특정 댓글을 삭제합니다. 대댓글이 있는 댓글을 삭제하면 대댓글도 함께 삭제됩니다. 작성자 또는 관리자만 삭제할 수 있습니다.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 댓글 ID */
+                    commentId: number;
+                };
+                cookie?: never;
             };
-          };
-        };
-        /** @description Tag already exists */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Tag already exists */
-              error?: string;
+            requestBody?: never;
+            responses: {
+                /** @description 댓글 삭제 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 인증되지 않은 사용자 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 권한 없음 (작성자가 아님) */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 댓글을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description Server error */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @example Failed to create tag */
-              error?: string;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/comments/like/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 댓글 좋아요/싫어요 수 조회
+         * @description 특정 댓글의 좋아요/싫어요 수와 사용자의 반응 상태를 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 사용자 ID (반응 상태 확인용) */
+                    userId?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description 댓글 ID */
+                    id: number;
+                };
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/users/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 특정 사용자 정보 조회
-     * @description ID를 사용하여 특정 사용자 정보를 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 사용자 ID */
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 사용자 정보 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['User'];
-          };
-        };
-        /** @description 사용자를 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /**
-     * 사용자 정보 수정
-     * @description ID를 사용하여 특정 사용자 정보를 수정합니다.
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 사용자 ID */
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            name?: string;
-            email?: string;
-            /** @enum {string} */
-            role?: 'USER' | 'ADMIN';
-          };
-        };
-      };
-      responses: {
-        /** @description 수정된 사용자 정보 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['User'];
-          };
-        };
-        /** @description 사용자를 찾을 수 없음 */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/users/count': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 전체 사용자 수 조회
-     * @description 전체 사용자 수를 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 사용자 수 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              count?: number;
+            requestBody?: never;
+            responses: {
+                /** @description 댓글 반응 정보 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            likes?: number;
+                            dislikes?: number;
+                            /** @enum {string} */
+                            userReaction?: "LIKE" | "DISLIKE" | null;
+                        };
+                    };
+                };
+                /** @description 댓글을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/visitor': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 오늘 방문자 수와 총 방문자 수 조회
-     * @description VisitorLog를 기반으로 오늘 방문자 수와 전체 방문자 수를 반환합니다.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 방문자 통계 반환 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              today?: number;
-              total?: number;
+        put?: never;
+        /**
+         * 댓글 좋아요/싫어요 토글
+         * @description 댓글에 좋아요/싫어요를 추가하거나 제거합니다.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 댓글 ID */
+                    id: number;
+                };
+                cookie?: never;
             };
-          };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: number;
+                        /** @enum {string} */
+                        type: "LIKE" | "DISLIKE";
+                    };
+                };
+            };
+            responses: {
+                /** @description 댓글 반응 토글 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            userReaction?: "LIKE" | "DISLIKE" | null;
+                            likes?: number;
+                            dislikes?: number;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 댓글을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    /**
-     * 방문자 기록 추가
-     * @description 방문자의 ip, userAgent, path를 VisitorLog에 기록합니다.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            path?: string;
-          };
+    "/api/comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description 기록 성공 */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get?: never;
+        put?: never;
+        /**
+         * 댓글 또는 대댓글 생성
+         * @description 새로운 댓글을 생성합니다. parentId가 있으면 대댓글, 없으면 댓글입니다. 인증된 사용자만 사용 가능합니다.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 댓글 내용 */
+                        content: string;
+                        /** @description 게시물 ID */
+                        postId: number;
+                        /** @description 부모 댓글 ID (대댓글인 경우) */
+                        parentId?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description 댓글 생성 성공 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            content?: string;
+                            createdAt?: string;
+                            author?: {
+                                name?: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 인증되지 않은 사용자 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 서버 에러 */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/api/post/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 특정 게시물 조회
+         * @description 게시물 ID를 기반으로 상세 정보를 조회합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 게시물 조회 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            title?: string;
+                            content?: string;
+                            author?: {
+                                id?: number;
+                                name?: string;
+                                email?: string;
+                            };
+                            category?: Record<string, never>;
+                            tags?: unknown[];
+                            comments?: unknown[];
+                            likes?: unknown[];
+                        };
+                    };
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * 게시물 수정
+         * @description 특정 게시물의 정보를 수정합니다.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 게시물 제목 */
+                        title?: string;
+                        /** @description 게시물 내용 */
+                        content?: string;
+                        /** @description 카테고리 ID */
+                        categoryId?: number;
+                        /** @description 태그 ID 배열 */
+                        tags?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description 게시물 수정 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /**
+         * 게시물 삭제
+         * @description 특정 게시물과 관련된 모든 데이터(댓글, 좋아요)를 삭제합니다.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 게시물 삭제 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Post deleted successfully */
+                            message?: string;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 특정 게시물 조회
+         * @description 게시물 slug를 기반으로 상세 정보를 조회합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 slug */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 게시물 조회 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            slug?: string;
+                            title?: string;
+                            content?: string;
+                            /** Format: date-time */
+                            createdAt?: string;
+                            /** Format: date-time */
+                            updatedAt?: string;
+                            views?: number;
+                            author?: {
+                                id?: number;
+                                name?: string;
+                                email?: string;
+                            };
+                            category?: {
+                                id?: number;
+                                name?: string;
+                                slug?: string;
+                            };
+                            tags?: {
+                                id?: number;
+                                name?: string;
+                                slug?: string;
+                            }[];
+                            comments?: {
+                                id?: number;
+                                content?: string;
+                                /** Format: date-time */
+                                createdAt?: string;
+                                author?: {
+                                    id?: number;
+                                    name?: string;
+                                };
+                                replies?: {
+                                    id?: number;
+                                    content?: string;
+                                    /** Format: date-time */
+                                    createdAt?: string;
+                                    author?: {
+                                        id?: number;
+                                        name?: string;
+                                    };
+                                }[];
+                            }[];
+                            likes?: {
+                                id?: number;
+                                user?: {
+                                    id?: number;
+                                    name?: string;
+                                };
+                            }[];
+                        };
+                    };
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * 게시물 수정
+         * @description 특정 게시물의 정보를 수정합니다.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 slug */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 게시물 제목 */
+                        title?: string;
+                        /** @description 게시물 내용 */
+                        content?: string;
+                        /** @description 카테고리 ID */
+                        categoryId?: number;
+                        /** @description 태그 ID 배열 */
+                        tags?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description 게시물 수정 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /**
+         * 게시물 삭제
+         * @description 특정 게시물과 관련된 모든 데이터(댓글, 좋아요)를 삭제합니다.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 게시물 slug */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 게시물 삭제 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Post deleted successfully */
+                            message?: string;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 게시물을 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts/like/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 포스트 좋아요 수 조회
+         * @description 특정 포스트의 좋아요 수와 사용자의 좋아요 여부를 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 사용자 ID (좋아요 여부 확인용) */
+                    userId?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description 포스트 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 좋아요 정보 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count?: number;
+                            isLiked?: boolean;
+                        };
+                    };
+                };
+                /** @description 포스트를 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * 포스트 좋아요 토글
+         * @description 포스트에 좋아요를 추가하거나 제거합니다.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 포스트 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description 좋아요 토글 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            isLiked?: boolean;
+                            count?: number;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 포스트를 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/posts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 게시물 목록 조회
+         * @description 검색어와 페이지네이션 옵션을 이용해 게시물 목록을 가져옵니다.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 게시물 검색어 (title, content) */
+                    search?: string;
+                    /** @description 카테고리 slug로 필터링 */
+                    category?: string;
+                    /** @description 태그 ID들을 쉼표로 구분하여 필터링 */
+                    tags?: string;
+                    /** @description 페이지 번호 */
+                    page?: number;
+                    /** @description 한 페이지 당 아이템 개수 */
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 게시물 목록과 메타데이터 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data?: {
+                                id?: number;
+                                title?: string;
+                                content?: string;
+                                /** Format: date-time */
+                                createdAt?: string;
+                                category?: {
+                                    name?: string;
+                                    slug?: string;
+                                };
+                                author?: {
+                                    name?: string;
+                                };
+                                tags?: {
+                                    id?: number;
+                                    name?: string;
+                                }[];
+                            }[];
+                            meta?: {
+                                pagination?: {
+                                    currentPage?: number;
+                                    totalPages?: number;
+                                    totalItems?: number;
+                                    itemsPerPage?: number;
+                                    hasNextPage?: boolean;
+                                    hasPrevPage?: boolean;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description 잘못된 페이지네이션 파라미터 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * 게시물 생성
+         * @description 새로운 게시물을 생성합니다. 관리자 또는 인증된 사용자만 접근 가능합니다.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 게시물 제목 */
+                        title: string;
+                        /** @description 게시물 내용 */
+                        content: string;
+                        /** @description 카테고리 ID */
+                        categoryId: number;
+                        /** @description 태그 ID 배열 (선택사항) */
+                        tags?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description 게시물이 성공적으로 생성됨 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            title?: string;
+                            content?: string;
+                            authorId?: number;
+                            categoryId?: number;
+                            /** Format: date-time */
+                            createdAt?: string;
+                            /** Format: date-time */
+                            updatedAt?: string;
+                        };
+                    };
+                };
+                /** @description 잘못된 요청 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description 인증되지 않은 사용자 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 권한 없음 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 모든 사용자 목록 조회
+         * @description 모든 사용자 목록을 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 사용자 목록 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["User"][];
+                    };
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** Create a new user (User Registration) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description User's full name */
+                        name: string;
+                        /**
+                         * Format: email
+                         * @description User's email address
+                         * @example user@example.com
+                         */
+                        email: string;
+                        /** @description User's password */
+                        password: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description User successfully created */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            name?: string;
+                            email?: string;
+                            /**
+                             * @default USER
+                             * @enum {string}
+                             */
+                            role: "USER" | "ADMIN";
+                            /** Format: date-time */
+                            createdAt?: string;
+                        };
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Invalid email or password */
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description User already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Email already in use */
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Internal server error */
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사이트 통계 조회
+         * @description 게시물, 사용자, 댓글, 조회수의 월별 통계를 조회합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 통계 데이터 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            posts?: {
+                                /** @description 전체 게시물 수 */
+                                total?: number;
+                                /** @description 이번달 게시물 수 */
+                                thisMonth?: number;
+                                /** @description 저번달 게시물 수 */
+                                lastMonth?: number;
+                            };
+                            users?: {
+                                /** @description 전체 사용자 수 */
+                                total?: number;
+                                /** @description 이번달 가입자 수 */
+                                thisMonth?: number;
+                                /** @description 저번달 가입자 수 */
+                                lastMonth?: number;
+                            };
+                            comments?: {
+                                /** @description 전체 댓글 수 */
+                                total?: number;
+                                /** @description 이번달 댓글 수 */
+                                thisMonth?: number;
+                                /** @description 저번달 댓글 수 */
+                                lastMonth?: number;
+                            };
+                            views?: {
+                                /** @description 전체 조회수 */
+                                total?: number;
+                                /** @description 이번달 조회수 */
+                                thisMonth?: number;
+                                /** @description 저번달 조회수 */
+                                lastMonth?: number;
+                            };
+                        };
+                    };
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Failed to fetch stats */
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/summarize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 블로그 포스트 요약 생성
+         * @description AI를 사용하여 블로그 포스트의 내용을 간결하게 요약합니다
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /**
+                         * @description 요약할 블로그 포스트 내용
+                         * @example 이 글에서는 React와 Next.js를 사용한 웹 개발에 대해 다룹니다...
+                         */
+                        content: string;
+                        /**
+                         * @description 블로그 포스트 제목
+                         * @example React와 Next.js로 현대적인 웹 애플리케이션 구축하기
+                         */
+                        title: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description 요약 생성 성공 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description 생성된 요약 텍스트
+                             * @example React와 Next.js를 활용한 웹 개발 방법론과 실제 구현 과정을 다룬 글입니다.
+                             */
+                            summary?: string;
+                        };
+                    };
+                };
+                /** @description 필수 필드 누락 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example 콘텐츠와 제목이 필요합니다. */
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description 서버 오류 또는 AI 요약 생성 실패 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example 요약 생성에 실패했습니다. */
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tags/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a specific tag
+         * @description Retrieve a tag by its ID with related posts
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Tag ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Tag retrieved successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * Update a tag
+         * @description Update a tag's name by its ID
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Tag ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Tag updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Name already in use */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete a tag
+         * @description Delete a tag by its ID
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Tag ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Tag deleted successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get all tags
+         * @description Retrieve a list of all tags with post counts
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description A list of tags */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            name?: string;
+                            /** Format: date-time */
+                            createdAt?: string;
+                            count?: {
+                                posts?: number;
+                            };
+                        }[];
+                    };
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new tag
+         * @description Create a new tag in the system
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @example JavaScript */
+                        name: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Tag created successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example 1 */
+                            id?: number;
+                            /** @example JavaScript */
+                            name?: string;
+                            /** Format: date-time */
+                            createdAt?: string;
+                        };
+                    };
+                };
+                /** @description Tag already exists */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Tag already exists */
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description Server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example Failed to create tag */
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 특정 사용자 정보 조회
+         * @description ID를 사용하여 특정 사용자 정보를 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 사용자 ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 사용자 정보 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["User"];
+                    };
+                };
+                /** @description 사용자를 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * 사용자 정보 수정
+         * @description ID를 사용하여 특정 사용자 정보를 수정합니다.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 사용자 ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        email?: string;
+                        /** @enum {string} */
+                        role?: "USER" | "ADMIN";
+                    };
+                };
+            };
+            responses: {
+                /** @description 수정된 사용자 정보 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["User"];
+                    };
+                };
+                /** @description 사용자를 찾을 수 없음 */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 전체 사용자 수 조회
+         * @description 전체 사용자 수를 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 사용자 수 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count?: number;
+                        };
+                    };
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/visitor": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 오늘 방문자 수와 총 방문자 수 조회
+         * @description VisitorLog를 기반으로 오늘 방문자 수와 전체 방문자 수를 반환합니다.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 방문자 통계 반환 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            today?: number;
+                            total?: number;
+                        };
+                    };
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * 방문자 기록 추가
+         * @description 방문자의 ip, userAgent, path를 VisitorLog에 기록합니다.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        path?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description 기록 성공 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 서버 에러 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Category: {
-      /** @description 카테고리 고유 ID */
-      id: number;
-      /** @description 카테고리 이름 */
-      name: string;
-      /** @description 카테고리 설명 */
-      description?: string | null;
-      /** @description 카테고리 슬러그 */
-      slug?: string;
-      /**
-       * Format: date-time
-       * @description 생성 일시
-       */
-      createdAt?: string;
-      _count?: {
-        /** @description 해당 카테고리의 게시글 수 */
-        posts?: number;
-      };
+    schemas: {
+        Category: {
+            /** @description 카테고리 고유 ID */
+            id: number;
+            /** @description 카테고리 이름 */
+            name: string;
+            /** @description 카테고리 설명 */
+            description?: string | null;
+            /** @description 카테고리 슬러그 */
+            slug?: string;
+            /** @description 부모 카테고리 ID (루트면 null) */
+            parentId?: number | null;
+            /**
+             * Format: date-time
+             * @description 생성 일시
+             */
+            createdAt?: string;
+            _count?: {
+                /** @description 해당 카테고리의 게시글 수 */
+                posts?: number;
+                /** @description 자식 카테고리 수 */
+                children?: number;
+            };
+        };
+        User: {
+            id?: number;
+            name?: string;
+            email?: string;
+            /** @enum {string} */
+            role?: "USER" | "ADMIN";
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            updatedAt?: string;
+            /** Format: date-time */
+            deletedAt?: string;
+        };
     };
-    User: {
-      id?: number;
-      name?: string;
-      email?: string;
-      /** @enum {string} */
-      role?: 'USER' | 'ADMIN';
-      /** Format: date-time */
-      createdAt?: string;
-      /** Format: date-time */
-      updatedAt?: string;
-      /** Format: date-time */
-      deletedAt?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/src/shared/api/openapi-types.ts
+++ b/src/shared/api/openapi-types.ts
@@ -234,7 +234,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description 각 카테고리의 게시글 수 포함 여부 */
+                    /** @description 각 카테고리의 게시글 수(_count.posts) 포함 여부. 자식 수(_count.children)는 항상 포함됩니다. */
                     includePostCount?: boolean;
                 };
                 header?: never;

--- a/src/shared/ui/AuthSidebar.tsx
+++ b/src/shared/ui/AuthSidebar.tsx
@@ -31,6 +31,7 @@ const styles = {
     base: 'relative rounded-xl transition-all duration-300 transform hover:-translate-y-1 shadow-md hover:shadow-xl bg-gradient-to-br from-white/8 to-white/4 border border-white/20 backdrop-blur-sm hover:bg-gradient-to-br hover:from-white/15 hover:to-white/8',
     dashboard: 'hover:border-blue-400/50',
     posts: 'hover:border-green-400/50',
+    categories: 'hover:border-cyan-400/50',
     tags: 'hover:border-yellow-400/50',
     newPost:
       'bg-gradient-to-br from-purple-500/80 to-blue-500/70 border border-purple-400/50 hover:bg-gradient-to-br hover:from-purple-500/90 hover:to-blue-500/80 hover:border-purple-400/70',
@@ -42,6 +43,7 @@ const styles = {
 const boxShadows = {
   dashboard: '0 0 10px rgba(59, 130, 246, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
   posts: '0 0 10px rgba(34, 197, 94, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
+  categories: '0 0 10px rgba(34, 211, 238, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
   tags: '0 0 10px rgba(251, 191, 36, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
   newPost: '0 0 15px rgba(139, 69, 255, 0.4), 0 0 30px rgba(139, 69, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.2)',
   quickAction:
@@ -127,6 +129,20 @@ const AuthSidebar = () => {
                   <Link href='/admin' className='flex items-center gap-3 p-3'>
                     <FileText className='w-5 h-5 text-green-400' />
                     <span className='text-white/90 font-medium'>All Posts</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+
+              {/* Categories Management */}
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  className={`${styles.menuButton.base} ${styles.menuButton.categories}`}
+                  style={{ boxShadow: boxShadows.categories }}
+                >
+                  <Link href='/admin/categories' className='flex items-center gap-3 p-3'>
+                    <Folder className='w-5 h-5 text-cyan-400' />
+                    <span className='text-white/90 font-medium'>Categories</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/src/shared/ui/modal.tsx
+++ b/src/shared/ui/modal.tsx
@@ -11,24 +11,36 @@ import {
 import type { ReactNode } from 'react';
 
 type ModalProps = {
-  trigger: ReactNode;
   title: string;
   description?: string;
   children: ReactNode;
+  /** 없으면 controlled `open`만으로 연다 (더미 Trigger 대신) */
+  trigger?: ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /** 닫힐 때 포커스 복귀 대상 지정 (기본은 Trigger) */
+  onCloseAutoFocus?: (event: Event) => void;
 };
 
-const Modal = ({ trigger, title, description, children, open, onOpenChange }: ModalProps) => {
+const Modal = ({
+  trigger,
+  title,
+  description,
+  children,
+  open,
+  onOpenChange,
+  onCloseAutoFocus,
+}: ModalProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
       <DialogContent
         className='sm:max-w-[425px] bg-gradient-to-br from-white/15 via-white/8 to-white/3 backdrop-blur-xl border border-white/30 shadow-2xl'
         style={{
           boxShadow:
             '0 0 30px rgba(255, 255, 255, 0.2), 0 0 60px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.3)',
         }}
+        onCloseAutoFocus={onCloseAutoFocus}
       >
         <DialogHeader className='space-y-3'>
           <DialogTitle className='text-xl font-bold text-white/95 drop-shadow-lg'>{title}</DialogTitle>

--- a/src/widgets/admin/category/index.ts
+++ b/src/widgets/admin/category/index.ts
@@ -1,0 +1,1 @@
+export { CategoryManagement } from './ui/category-management';

--- a/src/widgets/admin/category/ui/category-management.tsx
+++ b/src/widgets/admin/category/ui/category-management.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import {
+  buildCategoryTree,
+  flattenCategoryTree,
+  toCategoryListItems,
+  type CategoryTreeNode,
+} from '@/entities/category';
+import type { Category, CategoryListItem } from '@/entities/category/model';
+import { createCategory, deleteCategory, updateCategory } from '@/features/category/api/category-api';
+import { useCategories } from '@/features/category/model';
+import type { CategoryFormSchema } from '@/features/category/model/category-schema';
+import CategoryForm from '@/features/category/ui/category-form';
+import { Button } from '@/shadcn-ui/components/ui/button';
+import Modal from '@/shared/ui/modal';
+import { useQueryClient } from '@tanstack/react-query';
+import { FileText, Folder, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { queryKeys } from '@/shared/queryKeys';
+
+const toCategoryFormData = (category: CategoryListItem): Category => ({
+  id: String(category.id),
+  name: category.name,
+  slug: category.slug,
+  description: category.description ?? undefined,
+  parentId: category.parentId ?? null,
+});
+
+type CategoryRowProps = {
+  node: CategoryTreeNode<CategoryListItem>;
+  depth: number;
+  onEdit: (category: CategoryListItem) => void;
+  onDelete: (category: CategoryListItem) => void;
+};
+
+const CategoryRow = ({ node, depth, onEdit, onDelete }: CategoryRowProps) => {
+  const hasChildren = node.children.length > 0;
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <div
+        className='flex items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/5 px-3 py-2'
+        style={{ marginLeft: depth * 16 }}
+      >
+        <div className='flex min-w-0 items-center gap-2 text-white/90'>
+          {hasChildren ? (
+            <FolderOpen size={16} className='shrink-0 text-cyan-300' aria-hidden />
+          ) : depth > 0 ? (
+            <FileText size={16} className='shrink-0 text-blue-200' aria-hidden />
+          ) : (
+            <Folder size={16} className='shrink-0 text-blue-300' aria-hidden />
+          )}
+          <div className='min-w-0'>
+            <p className='truncate font-medium'>{node.name}</p>
+            <p className='truncate text-xs text-white/50'>/{node.slug}</p>
+          </div>
+        </div>
+        <div className='flex shrink-0 items-center gap-2'>
+          <Button type='button' variant='ghost' size='sm' onClick={() => onEdit(node)} aria-label={`${node.name} 수정`}>
+            <Pencil size={14} />
+            수정
+          </Button>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            className='text-red-300 hover:text-red-200'
+            onClick={() => onDelete(node)}
+            aria-label={`${node.name} 삭제`}
+          >
+            <Trash2 size={14} />
+            삭제
+          </Button>
+        </div>
+      </div>
+      {node.children.map((child) => (
+        <CategoryRow key={child.id} node={child} depth={depth + 1} onEdit={onEdit} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+export const CategoryManagement = () => {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useCategories();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<CategoryListItem | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const categories = useMemo(() => toCategoryListItems(data), [data]);
+
+  const tree = useMemo(() => buildCategoryTree(categories), [categories]);
+  const flatCount = useMemo(() => flattenCategoryTree(tree).length, [tree]);
+
+  const invalidateCategories = async () => {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.category.all.queryKey });
+  };
+
+  const handleCreate = async (formData: CategoryFormSchema) => {
+    setErrorMessage(null);
+    try {
+      await createCategory(formData);
+      await invalidateCategories();
+      setCreateOpen(false);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '카테고리 생성에 실패했습니다.');
+    }
+  };
+
+  const handleUpdate = async (formData: CategoryFormSchema) => {
+    if (!editingCategory) return;
+    setErrorMessage(null);
+    try {
+      await updateCategory(String(editingCategory.id), formData);
+      await invalidateCategories();
+      setEditingCategory(null);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '카테고리 수정에 실패했습니다.');
+    }
+  };
+
+  const handleDelete = async (category: CategoryListItem) => {
+    const confirmed = window.confirm(`"${category.name}" 카테고리를 삭제할까요?`);
+    if (!confirmed) return;
+
+    setErrorMessage(null);
+    try {
+      await deleteCategory(String(category.id));
+      await invalidateCategories();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '카테고리 삭제에 실패했습니다.');
+    }
+  };
+
+  return (
+    <div className='flex flex-1 flex-col gap-4 px-4 py-4 md:px-6 md:py-6'>
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <div>
+          <h1 className='text-2xl font-bold text-white/95'>Categories</h1>
+          <p className='text-sm text-white/60'>부모 카테고리를 지정해 트리로 그룹핑할 수 있습니다.</p>
+        </div>
+        <Modal
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          title='새 카테고리 생성'
+          description='부모를 고르면 사이드바 트리의 자식으로 표시됩니다.'
+          trigger={
+            <Button type='button' className='gap-2'>
+              <Plus size={16} />
+              새 카테고리
+            </Button>
+          }
+        >
+          <CategoryForm onSubmit={handleCreate} />
+        </Modal>
+      </div>
+
+      {errorMessage && (
+        <div className='rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm text-red-200'>
+          {errorMessage}
+        </div>
+      )}
+
+      <div className='rounded-2xl border border-white/15 bg-white/5 p-4 backdrop-blur-sm'>
+        <div className='mb-4 flex items-center justify-between text-sm text-white/60'>
+          <span>총 {flatCount}개</span>
+          <span>수정에서 부모 카테고리를 바꾸면 트리 위치가 변경됩니다.</span>
+        </div>
+
+        {isLoading ? (
+          <p className='text-white/70'>불러오는 중...</p>
+        ) : tree.length === 0 ? (
+          <p className='text-white/70'>카테고리가 없습니다. 새 카테고리를 만들어 주세요.</p>
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {tree.map((node) => (
+              <CategoryRow
+                key={node.id}
+                node={node}
+                depth={0}
+                onEdit={setEditingCategory}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Modal
+        open={!!editingCategory}
+        onOpenChange={(open) => {
+          if (!open) setEditingCategory(null);
+        }}
+        title='카테고리 수정'
+        description='부모 카테고리를 변경해 자식으로 옮길 수 있습니다.'
+        trigger={<span className='hidden' />}
+      >
+        {editingCategory && (
+          <CategoryForm key={editingCategory.id} onSubmit={handleUpdate} initialData={toCategoryFormData(editingCategory)} />
+        )}
+      </Modal>
+    </div>
+  );
+};

--- a/src/widgets/admin/category/ui/category-management.tsx
+++ b/src/widgets/admin/category/ui/category-management.tsx
@@ -13,9 +13,10 @@ import type { CategoryFormSchema } from '@/features/category/model/category-sche
 import CategoryForm from '@/features/category/ui/category-form';
 import { Button } from '@/shadcn-ui/components/ui/button';
 import Modal from '@/shared/ui/modal';
+import { toast } from '@/shared/ui/toast/useToast';
 import { useQueryClient } from '@tanstack/react-query';
 import { FileText, Folder, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { queryKeys } from '@/shared/queryKeys';
 
 const toCategoryFormData = (category: CategoryListItem): Category => ({
@@ -29,12 +30,12 @@ const toCategoryFormData = (category: CategoryListItem): Category => ({
 type CategoryRowProps = {
   node: CategoryTreeNode<CategoryListItem>;
   depth: number;
-  onEdit: (category: CategoryListItem) => void;
+  onEdit: (category: CategoryListItem, trigger: HTMLButtonElement) => void;
   onDelete: (category: CategoryListItem) => void;
 };
 
 const CategoryRow = ({ node, depth, onEdit, onDelete }: CategoryRowProps) => {
-  const hasChildren = node.children.length > 0;
+  const hasChildren = (node._count?.children ?? node.children.length) > 0;
 
   return (
     <div className='flex flex-col gap-2'>
@@ -52,11 +53,20 @@ const CategoryRow = ({ node, depth, onEdit, onDelete }: CategoryRowProps) => {
           )}
           <div className='min-w-0'>
             <p className='truncate font-medium'>{node.name}</p>
-            <p className='truncate text-xs text-white/50'>/{node.slug}</p>
+            <p className='truncate text-xs text-white/50'>
+              /{node.slug}
+              {hasChildren ? ` · 하위 ${node._count?.children ?? node.children.length}` : ''}
+            </p>
           </div>
         </div>
         <div className='flex shrink-0 items-center gap-2'>
-          <Button type='button' variant='ghost' size='sm' onClick={() => onEdit(node)} aria-label={`${node.name} 수정`}>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={(event) => onEdit(node, event.currentTarget)}
+            aria-label={`${node.name} 수정`}
+          >
             <Pencil size={14} />
             수정
           </Button>
@@ -66,7 +76,9 @@ const CategoryRow = ({ node, depth, onEdit, onDelete }: CategoryRowProps) => {
             size='sm'
             className='text-red-300 hover:text-red-200'
             onClick={() => onDelete(node)}
-            aria-label={`${node.name} 삭제`}
+            disabled={hasChildren}
+            aria-label={hasChildren ? `${node.name} 삭제 불가 (하위 카테고리 있음)` : `${node.name} 삭제`}
+            title={hasChildren ? '하위 카테고리를 먼저 삭제하세요' : undefined}
           >
             <Trash2 size={14} />
             삭제
@@ -85,7 +97,7 @@ export const CategoryManagement = () => {
   const { data, isLoading } = useCategories();
   const [createOpen, setCreateOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<CategoryListItem | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const editTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   const categories = useMemo(() => toCategoryListItems(data), [data]);
 
@@ -97,38 +109,38 @@ export const CategoryManagement = () => {
   };
 
   const handleCreate = async (formData: CategoryFormSchema) => {
-    setErrorMessage(null);
-    try {
-      await createCategory(formData);
-      await invalidateCategories();
-      setCreateOpen(false);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '카테고리 생성에 실패했습니다.');
-    }
+    await createCategory(formData);
+    await invalidateCategories();
+    setCreateOpen(false);
   };
 
   const handleUpdate = async (formData: CategoryFormSchema) => {
     if (!editingCategory) return;
-    setErrorMessage(null);
-    try {
-      await updateCategory(String(editingCategory.id), formData);
-      await invalidateCategories();
-      setEditingCategory(null);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '카테고리 수정에 실패했습니다.');
-    }
+    await updateCategory(String(editingCategory.id), formData);
+    await invalidateCategories();
+    setEditingCategory(null);
+  };
+
+  const handleEdit = (category: CategoryListItem, trigger: HTMLButtonElement) => {
+    editTriggerRef.current = trigger;
+    setEditingCategory(category);
+  };
+
+  const handleEditModalCloseAutoFocus = (event: Event) => {
+    event.preventDefault();
+    editTriggerRef.current?.focus();
   };
 
   const handleDelete = async (category: CategoryListItem) => {
     const confirmed = window.confirm(`"${category.name}" 카테고리를 삭제할까요?`);
     if (!confirmed) return;
 
-    setErrorMessage(null);
     try {
       await deleteCategory(String(category.id));
       await invalidateCategories();
+      toast.success(`"${category.name}" 카테고리를 삭제했습니다.`);
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '카테고리 삭제에 실패했습니다.');
+      toast.error(error instanceof Error ? error.message : '카테고리 삭제에 실패했습니다.');
     }
   };
 
@@ -155,12 +167,6 @@ export const CategoryManagement = () => {
         </Modal>
       </div>
 
-      {errorMessage && (
-        <div className='rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm text-red-200'>
-          {errorMessage}
-        </div>
-      )}
-
       <div className='rounded-2xl border border-white/15 bg-white/5 p-4 backdrop-blur-sm'>
         <div className='mb-4 flex items-center justify-between text-sm text-white/60'>
           <span>총 {flatCount}개</span>
@@ -178,7 +184,7 @@ export const CategoryManagement = () => {
                 key={node.id}
                 node={node}
                 depth={0}
-                onEdit={setEditingCategory}
+                onEdit={handleEdit}
                 onDelete={handleDelete}
               />
             ))}
@@ -193,7 +199,7 @@ export const CategoryManagement = () => {
         }}
         title='카테고리 수정'
         description='부모 카테고리를 변경해 자식으로 옮길 수 있습니다.'
-        trigger={<span className='hidden' />}
+        onCloseAutoFocus={handleEditModalCloseAutoFocus}
       >
         {editingCategory && (
           <CategoryForm key={editingCategory.id} onSubmit={handleUpdate} initialData={toCategoryFormData(editingCategory)} />

--- a/src/widgets/post/ui/CategoryTree.tsx
+++ b/src/widgets/post/ui/CategoryTree.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import {
+  buildCategoryTree,
+  collectAncestorIds,
+  type CategoryTreeNode,
+} from '@/entities/category/lib/build-category-tree';
+import type { CategoryListItem } from '@/entities/category/model';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+type CategoryTreeProps = {
+  categories: CategoryListItem[];
+  currentCategorySlug: string | null;
+  onSelect: (slug: string) => void;
+};
+
+const getActiveClassName = (isActive: boolean) =>
+  isActive
+    ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
+    : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0';
+
+type CategoryTreeItemProps = {
+  node: CategoryTreeNode<CategoryListItem>;
+  depth: number;
+  currentCategorySlug: string | null;
+  expandedIds: Set<number>;
+  onToggle: (id: number) => void;
+  onSelect: (slug: string) => void;
+};
+
+const CategoryTreeItem = ({
+  node,
+  depth,
+  currentCategorySlug,
+  expandedIds,
+  onToggle,
+  onSelect,
+}: CategoryTreeItemProps) => {
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expandedIds.has(node.id);
+  const isActive = currentCategorySlug === node.slug;
+
+  return (
+    <div className='flex flex-col gap-1'>
+      <div className='flex items-center gap-1' style={{ paddingLeft: depth * 12 }}>
+        {hasChildren ? (
+          <button
+            type='button'
+            className='shrink-0 p-0.5 rounded text-blue-200 hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400'
+            aria-label={isExpanded ? `${node.name} 접기` : `${node.name} 펼치기`}
+            aria-expanded={isExpanded}
+            onClick={() => onToggle(node.id)}
+          >
+            {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          </button>
+        ) : (
+          <span className='inline-block w-5 shrink-0' aria-hidden />
+        )}
+        <motion.button
+          type='button'
+          animate={{
+            boxShadow: isActive ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
+          }}
+          whileHover={{
+            scale: 1.03,
+            boxShadow: isActive ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
+          }}
+          whileTap={{ scale: 0.97 }}
+          className={`flex-1 flex items-center gap-2 text-left px-2 py-1 rounded-lg font-mono transition relative ${getActiveClassName(isActive)}`}
+          onClick={() => onSelect(node.slug)}
+        >
+          {hasChildren ? (
+            isExpanded ? (
+              <FolderOpen size={15} className='shrink-0 opacity-80' aria-hidden />
+            ) : (
+              <Folder size={15} className='shrink-0 opacity-80' aria-hidden />
+            )
+          ) : (
+            <FileText size={15} className='shrink-0 opacity-80' aria-hidden />
+          )}
+          <span className='truncate'>{node.name}</span>
+        </motion.button>
+      </div>
+
+      <AnimatePresence initial={false}>
+        {hasChildren && isExpanded && (
+          <motion.div
+            key={`children-${node.id}`}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className='overflow-hidden flex flex-col gap-1'
+          >
+            {node.children.map((child) => (
+              <CategoryTreeItem
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                currentCategorySlug={currentCategorySlug}
+                expandedIds={expandedIds}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export const CategoryTree = ({ categories, currentCategorySlug, onSelect }: CategoryTreeProps) => {
+  const tree = useMemo(() => buildCategoryTree(categories), [categories]);
+  const activeCategory = useMemo(
+    () => categories.find((category) => category.slug === currentCategorySlug) ?? null,
+    [categories, currentCategorySlug],
+  );
+  const ancestorIds = useMemo(
+    () => collectAncestorIds(categories, activeCategory?.id ?? null),
+    [categories, activeCategory],
+  );
+
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(() => new Set(ancestorIds));
+
+  useEffect(() => {
+    if (ancestorIds.size === 0) return;
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      for (const id of ancestorIds) {
+        next.add(id);
+      }
+      return next;
+    });
+  }, [ancestorIds]);
+
+  const handleToggle = (id: number) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className='flex flex-col gap-1'>
+      {tree.map((node) => (
+        <CategoryTreeItem
+          key={node.id}
+          node={node}
+          depth={0}
+          currentCategorySlug={currentCategorySlug}
+          expandedIds={expandedIds}
+          onToggle={handleToggle}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/widgets/post/ui/MobileNavbar.tsx
+++ b/src/widgets/post/ui/MobileNavbar.tsx
@@ -2,8 +2,11 @@
 import { useCategories } from '@/features/category/model';
 import { useTags } from '@/features/tag/model/use-tags';
 import { Tag } from '@/features/tag/ui';
+import { toCategoryListItems } from '@/entities/category';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter, usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+import { CategoryTree } from './CategoryTree';
 
 export const MobileNavbar = ({
   menuOpen,
@@ -12,13 +15,23 @@ export const MobileNavbar = ({
   menuOpen: boolean;
   setMenuOpen: (menuOpen: boolean) => void;
 }) => {
-  const { data: categories } = useCategories();
+  const { data } = useCategories();
   const { data: tags } = useTags();
   const router = useRouter();
   const pathname = usePathname();
 
-  const currentCategorySlug = pathname.startsWith('/blog/category/') ? pathname.split('/blog/category/')[1] : null;
+  const categories = useMemo(() => toCategoryListItems(data), [data]);
+
+  const currentCategorySlug = (() => {
+    const match = pathname.match(/^\/blog\/category\/([^\/]+)/);
+    return match?.[1] ? decodeURIComponent(match[1]) : null;
+  })();
   const isAllPage = pathname === '/blog/all';
+
+  const handleSelectCategory = (slug: string) => {
+    router.push(`/blog/category/${slug}`);
+    setMenuOpen(false);
+  };
 
   return (
     <AnimatePresence>
@@ -36,7 +49,7 @@ export const MobileNavbar = ({
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: 80, opacity: 0 }}
             transition={{ duration: 0.25 }}
-            className='w-72 max-w-full h-full flex flex-col gap-8 p-6 bg-[#181c2a]/90 border-l border-blue-300 shadow-[0_0_16px_4px_#7dd3fc55] backdrop-blur-sm'
+            className='w-72 max-w-full h-full flex flex-col gap-8 p-6 bg-[#181c2a]/90 border-l border-blue-300 shadow-[0_0_16px_4px_#7dd3fc55] backdrop-blur-sm overflow-y-auto'
           >
             <div className='flex items-center justify-between mb-4'>
               <span className='font-extrabold text-lg font-mono text-blue-100'>Category</span>
@@ -71,37 +84,17 @@ export const MobileNavbar = ({
                   }`}
                 onClick={() => {
                   router.push('/blog/all');
+                  setMenuOpen(false);
                 }}
               >
                 전체
               </motion.button>
 
-              {categories?.map((cat) => (
-                <motion.button
-                  key={cat.id}
-                  type='button'
-                  animate={{
-                    boxShadow: currentCategorySlug === cat.slug ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
-                  }}
-                  whileHover={{
-                    scale: 1.06,
-                    boxShadow:
-                      currentCategorySlug === cat.slug ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
-                  }}
-                  whileTap={{ scale: 0.97 }}
-                  className={`text-left px-2 py-1 rounded-lg font-mono transition relative
-                    ${
-                      currentCategorySlug === cat.slug
-                        ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
-                        : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0'
-                    }`}
-                  onClick={() => {
-                    router.push(`/blog/category/${cat.slug}`);
-                  }}
-                >
-                  {cat.name}
-                </motion.button>
-              ))}
+              <CategoryTree
+                categories={categories}
+                currentCategorySlug={currentCategorySlug}
+                onSelect={handleSelectCategory}
+              />
             </nav>
             <div>
               <h2 className='font-extrabold text-base px-3 mb-2 font-mono text-blue-100'>Tags</h2>

--- a/src/widgets/post/ui/Sidebar.tsx
+++ b/src/widgets/post/ui/Sidebar.tsx
@@ -4,20 +4,24 @@ import { useTags } from '@/features/tag/model/use-tags';
 import { Tag } from '@/features/tag/ui';
 import { VisitorCounter } from '@/features/blog/ui';
 import { useCategories } from '@/features/category/model';
+import { toCategoryListItems } from '@/entities/category';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRouter, usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { SparklesCore } from '@/shared/ui/sparkles';
 import { SidebarSkeleton } from '@/shared/ui/skeleton';
+import { CategoryTree } from './CategoryTree';
 
 export default function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
-  const { data: categories, isLoading } = useCategories();
+  const { data, isLoading } = useCategories();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   const { data: tags } = useTags();
+
+  const categories = useMemo(() => toCategoryListItems(data), [data]);
 
   // pathname에서 category slug 추출 (/blog/category/react -> react)
   const currentCategorySlug = (() => {
@@ -99,32 +103,11 @@ export default function Sidebar() {
                   전체
                 </motion.button>
 
-                {categories?.map((cat) => (
-                  <motion.button
-                    key={cat.id}
-                    type='button'
-                    animate={{
-                      boxShadow: currentCategorySlug === cat.slug ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
-                    }}
-                    whileHover={{
-                      scale: 1.06,
-                      boxShadow:
-                        currentCategorySlug === cat.slug ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
-                    }}
-                    whileTap={{ scale: 0.97 }}
-                    className={`text-left px-2 py-1 rounded-lg font-mono transition relative
-                        ${
-                          currentCategorySlug === cat.slug
-                            ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
-                            : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0'
-                        }`}
-                    onClick={() => {
-                      router.push(`/blog/category/${cat.slug}`);
-                    }}
-                  >
-                    {cat.name}
-                  </motion.button>
-                ))}
+                <CategoryTree
+                  categories={categories}
+                  currentCategorySlug={currentCategorySlug}
+                  onSelect={(slug) => router.push(`/blog/category/${slug}`)}
+                />
               </nav>
             </div>
             <div>

--- a/src/widgets/post/ui/index.ts
+++ b/src/widgets/post/ui/index.ts
@@ -6,4 +6,5 @@ export { default as Sidebar } from './Sidebar';
 export { MobileNavbar } from './MobileNavbar';
 export { SpaceBackground } from './SpaceBackground';
 export { SearchBar } from './SearchBar';
+export { CategoryTree } from './CategoryTree';
 export * from './ComputerBackground/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,8 @@
   },
   "include": [
     "next-env.d.ts",
+    "css.d.ts",
+    "next-auth.d.ts",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",


### PR DESCRIPTION
## Summary
- Category에 `parentId` self-relation을 추가해 계층 카테고리를 지원
- 블로그 사이드바/모바일에 접기·펼치기 트리 UI 적용
- 관리자 `/admin/categories`에서 부모 지정으로 자식 이동 가능
- OpenAPI 타입 재생성 및 ARCHITECTURE.md에 Server/Client 경계 가이드 추가

## Test plan
- [ ] `pnpm exec prisma migrate deploy` 후 기존 카테고리가 루트로 보이는지 확인
- [ ] `/admin/categories`에서 카테고리 수정 → 부모 지정 → 사이드바 트리에 반영되는지 확인
- [ ] 사이드바에서 chevron 접기/펼치기, 부모/자식 클릭 이동 확인
- [ ] 모바일 메뉴에서도 트리가 동일하게 동작하는지 확인
- [ ] 자기 자신/자손을 부모로 지정할 때 API가 거부하는지 확인
- [ ] 자식이 있는 카테고리 삭제가 거부되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리자 화면에서 카테고리를 생성·수정·삭제하고 계층 구조로 관리할 수 있습니다.
  * 카테고리의 부모를 지정하거나 변경할 수 있으며, 하위 카테고리가 있는 항목은 삭제할 수 없습니다.
  * 게시글 탐색 영역에 접기·펼치기가 가능한 계층형 카테고리 트리를 제공합니다.
  * 카테고리 선택기에 계층 깊이와 들여쓰기가 표시됩니다.

* **문서**
  * 프로젝트 아키텍처 문서에 Server Component와 Client Component 사용 기준을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->