### PR TITLE
fix(portfolio): 프로젝트 카드 레이아웃·FashionBiz 링크 정리

### DIFF
--- a/src/entities/portfolio/model/types.ts
+++ b/src/entities/portfolio/model/types.ts
@@ -56,8 +56,8 @@ export type PortfolioProject = {
   image: string;
   /** 배포된 사이트 URL. 없으면 VIEW LIVE 미노출 */
   liveUrl?: string;
-  /** GitHub 등 소스 저장소 URL */
-  sourceUrl: string;
+  /** GitHub 등 소스 저장소 URL. 없으면 SOURCE 미노출 */
+  sourceUrl?: string;
 };
 
 export interface Experience {

--- a/src/widgets/portfolio/consts/portfolioProject.ts
+++ b/src/widgets/portfolio/consts/portfolioProject.ts
@@ -17,6 +17,6 @@ export const portfolioProjects: PortfolioProject[] = [
     description:
       'Next.js App Router로 전체 페이지를 구현하고, Apollo Client로 GraphQL 연동과 상태 관리를 담당했습니다. Google 번역 API 다국어 지원과 Metatag·서버 컴포넌트 기반 SEO 최적화를 적용했습니다.',
     image: '/assets/images/project2.jpg',
-    sourceUrl: 'https://github.com/scs0209',
+    liveUrl: 'https://fashionbiz.co.kr/',
   },
 ];

--- a/src/widgets/portfolio/ui/PortfolioOverlay.tsx
+++ b/src/widgets/portfolio/ui/PortfolioOverlay.tsx
@@ -65,7 +65,7 @@ export function PortfolioOverlay({ isExiting, onExitComplete }: { isExiting?: bo
 
                     <div className='p-5 flex flex-1 min-h-0 flex-col'>
                       <p className={`${overlayStyles.subtitle} mb-3 shrink-0`}>{project.subtitle}</p>
-                      <p className={`${overlayStyles.body} flex-1`}>{project.description}</p>
+                      <p className={`${overlayStyles.body} flex-1 min-h-0 overflow-y-auto`}>{project.description}</p>
 
                       {(project.liveUrl || project.sourceUrl) && (
                         <div className='mt-auto flex gap-3 pt-4 shrink-0'>

--- a/src/widgets/portfolio/ui/PortfolioOverlay.tsx
+++ b/src/widgets/portfolio/ui/PortfolioOverlay.tsx
@@ -52,38 +52,45 @@ export function PortfolioOverlay({ isExiting, onExitComplete }: { isExiting?: bo
             <AnimatePresence>
               {portfolioProjects.map((project, index) => (
                 <motion.div key={`${project.id}-${animationKey}`} variants={cardVariants}>
-                  <OverlayPanel className='overflow-hidden h-[480px] w-full flex flex-col'>
-                    <div className='h-40 border-b border-neon-cream/20 flex items-center justify-center bg-black/40'>
+                  <OverlayPanel
+                    className='overflow-hidden h-[480px] w-full'
+                    contentClassName='flex h-full flex-col'
+                  >
+                    <div className='h-40 shrink-0 border-b border-neon-cream/20 flex items-center justify-center bg-black/40'>
                       <div className='text-center'>
                         <p className={`${overlayStyles.kicker} mb-2`}>PROJECT {String(index + 1).padStart(2, '0')}</p>
                         <p className={`${overlayStyles.title} text-sm`}>{project.title}</p>
                       </div>
                     </div>
 
-                    <div className='p-5 flex flex-col flex-1 relative'>
-                      <p className={`${overlayStyles.subtitle} mb-3`}>{project.subtitle}</p>
-                      <p className={`${overlayStyles.body} line-clamp-6`}>{project.description}</p>
+                    <div className='p-5 flex flex-1 min-h-0 flex-col'>
+                      <p className={`${overlayStyles.subtitle} mb-3 shrink-0`}>{project.subtitle}</p>
+                      <p className={`${overlayStyles.body} flex-1`}>{project.description}</p>
 
-                      <div className='absolute bottom-5 left-5 right-5 flex gap-3'>
-                        {project.liveUrl ? (
-                          <a
-                            href={project.liveUrl}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            className={`${overlayStyles.button} flex-1 text-center text-xs`}
-                          >
-                            VIEW LIVE
-                          </a>
-                        ) : null}
-                        <a
-                          href={project.sourceUrl}
-                          target='_blank'
-                          rel='noopener noreferrer'
-                          className={`${overlayStyles.buttonPrimary} flex-1 text-center text-xs py-2.5`}
-                        >
-                          SOURCE
-                        </a>
-                      </div>
+                      {(project.liveUrl || project.sourceUrl) && (
+                        <div className='mt-auto flex gap-3 pt-4 shrink-0'>
+                          {project.liveUrl ? (
+                            <a
+                              href={project.liveUrl}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              className={`${overlayStyles.button} flex-1 text-center text-xs`}
+                            >
+                              VIEW LIVE
+                            </a>
+                          ) : null}
+                          {project.sourceUrl ? (
+                            <a
+                              href={project.sourceUrl}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              className={`${overlayStyles.button} flex-1 text-center text-xs`}
+                            >
+                              SOURCE
+                            </a>
+                          ) : null}
+                        </div>
+                      )}
                     </div>
                   </OverlayPanel>
                 </motion.div>


### PR DESCRIPTION
## Summary
- FashionBiz를 `liveUrl`(https://fashionbiz.co.kr/)로 연결하고, source가 없으면 SOURCE 미노출
- 프로젝트 카드에서 body가 남는 공간을 채우고 버튼을 최하단에 고정
- VIEW LIVE / SOURCE 버튼 크기를 동일하게 맞춤

## Test plan
- [ ] Works 오버레이에서 FashionBiz 카드에 VIEW LIVE만 보이고 fashionbiz.co.kr로 이동하는지 확인
- [ ] 3D Blog 카드에 SOURCE만 보이고 GitHub로 이동하는지 확인
- [ ] 카드 body와 버튼이 겹치지 않고 버튼이 최하단에 정렬되는지 확인
- [ ] VIEW LIVE / SOURCE가 함께 있을 때 버튼 높이가 같은지 확인


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 포트폴리오 카드에서 배포 사이트 링크와 소스 코드 링크를 각각 표시합니다.
  * 링크가 제공된 경우에만 해당 링크 영역이 노출됩니다.
  * 소스 코드 링크가 없는 프로젝트에서는 `SOURCE` 항목이 표시되지 않습니다.

* **개선 사항**
  * 포트폴리오 오버레이에서 설명 영역과 링크 영역을 분리해 가독성을 높였습니다.
  * 링크 영역을 하단에 고정해 카드 정보를 더 안정적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->