### PR TITLE
fix: 홈 WalkingAvatar WASD 이동 수정

### DIFF
--- a/src/shared/ui/Loader.tsx
+++ b/src/shared/ui/Loader.tsx
@@ -1,7 +1,7 @@
-import { Html, useProgress } from '@react-three/drei';
+import { Html } from '@react-three/drei';
 
+/** useProgress는 에셋 로드 중 다른 컴포넌트 렌더에서 setState를 유발할 수 있어 사용하지 않음 */
 export const CanvasLoader = () => {
-  const { progress } = useProgress();
   return (
     <Html
       as='div'
@@ -22,7 +22,7 @@ export const CanvasLoader = () => {
           marginTop: 40,
         }}
       >
-        {progress.toFixed(2)}%
+        Loading…
       </p>
     </Html>
   );

--- a/src/views/home/HomeCanvas.tsx
+++ b/src/views/home/HomeCanvas.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { Suspense, useMemo, useEffect, useState } from 'react';
+import { OrbitControls, Sparkles, Stars, useFBX, useGLTF } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
-import { SceneClickHandler, WalkingAvatar, Planet, FallingAstronaut, RoomModel } from '@/widgets/home';
-import { CanvasLoader, Earth, Scene, Sun } from '@/shared/ui';
-import { OrbitControls, Sparkles, Stars, useGLTF } from '@react-three/drei';
+import { useAnimationFrame, useMotionValue, useSpring } from 'framer-motion';
 import { useTheme } from 'next-themes';
-import { motion, useMotionValue, useSpring, useAnimationFrame } from 'framer-motion';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { CanvasLoader, Earth, Scene, Sun } from '@/shared/ui';
+import { FallingAstronaut, Planet, RoomModel, SceneClickHandler, WalkingAvatar } from '@/widgets/home';
 
 export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) => void }) => {
   const { theme } = useTheme();
@@ -22,6 +22,8 @@ export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) =
       } else {
         useGLTF.preload('/space_boi.glb');
         useGLTF.preload('/WalkingAstro.glb');
+        useFBX.preload('/snp.fbx');
+        useFBX.preload('/Typing.fbx');
       }
     }, 100);
 
@@ -40,6 +42,9 @@ export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) =
 
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [displayTheme, setDisplayTheme] = useState(theme);
+  const isTransitioningRef = useRef(false);
+  const displayThemeRef = useRef(theme);
+  const themeRef = useRef(theme);
 
   const darkRadius = 20;
   const lightRadius = 100;
@@ -57,35 +62,79 @@ export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) =
 
   const radius = useMotionValue(displayTheme === 'dark' ? darkRadius : lightRadius);
   const spring = useSpring(radius, { stiffness: 80, damping: 20 });
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const starNodesRef = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    displayThemeRef.current = displayTheme;
+  }, [displayTheme]);
+
+  useEffect(() => {
+    themeRef.current = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    isTransitioningRef.current = isTransitioning;
+  }, [isTransitioning]);
 
   useEffect(() => {
     if (theme !== displayTheme) {
       setIsTransitioning(true);
+      isTransitioningRef.current = true;
       if (theme === 'dark') {
         radius.set(darkRadius);
         setTimeout(() => {
           setDisplayTheme('dark');
+          displayThemeRef.current = 'dark';
           setIsTransitioning(false);
+          isTransitioningRef.current = false;
         }, 500);
       } else {
         setDisplayTheme('light');
+        displayThemeRef.current = 'light';
         setTimeout(() => {
           radius.set(lightRadius);
           setIsTransitioning(false);
+          isTransitioningRef.current = false;
         }, 50);
       }
     }
   }, [theme, displayTheme, radius]);
 
-  const [currentRadius, setCurrentRadius] = useState(radius.get());
-  const [overlayOpacity, setOverlayOpacity] = useState(displayTheme === 'dark' ? 1 : 0);
+  // React setState 없이 DOM만 갱신 — WalkingAvatar 리렌더/위치 리셋 방지
   useAnimationFrame(() => {
-    setCurrentRadius(spring.get());
-    if (displayTheme === 'dark' || (theme === 'dark' && isTransitioning)) {
-      setOverlayOpacity(1);
+    const overlay = overlayRef.current;
+    if (!overlay) {
+      return;
+    }
+
+    const currentRadius = spring.get();
+    const currentDisplayTheme = displayThemeRef.current;
+    const currentTheme = themeRef.current;
+    const transitioning = isTransitioningRef.current;
+
+    let overlayOpacity = 0;
+    if (currentDisplayTheme === 'dark' || (currentTheme === 'dark' && transitioning)) {
+      overlayOpacity = 1;
     } else {
       const progress = (currentRadius - darkRadius) / (lightRadius - darkRadius);
-      setOverlayOpacity(Math.max(0, 1 - progress));
+      overlayOpacity = Math.max(0, 1 - progress);
+    }
+
+    overlay.style.opacity = String(overlayOpacity);
+    overlay.style.background = `radial-gradient(circle at 50% 50%, transparent ${currentRadius}%, #000 ${currentRadius + 10}%)`;
+    overlay.style.display =
+      currentDisplayTheme === 'dark' || overlayOpacity > 0 ? 'block' : 'none';
+
+    const minDistance = currentRadius * 0.6;
+    for (const starEl of starNodesRef.current) {
+      if (!starEl) {
+        continue;
+      }
+      const x = Number(starEl.dataset.x);
+      const y = Number(starEl.dataset.y);
+      const distance = Math.hypot(x - 50, y - 50);
+      starEl.style.display = distance > minDistance ? 'block' : 'none';
     }
   });
 
@@ -110,9 +159,6 @@ export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) =
               <SceneClickHandler />
               <Stars radius={100} depth={100} count={4000} factor={4} saturation={0} fade speed={0.2} />
               <Sparkles count={300} size={3} speed={0.02} opacity={1} scale={20} color='#fff3b0' />
-              {/* <Suspense fallback={<CanvasLoader />}>
-                <AnimateAvatar scale={3000} position={[0, 5, 0]} />
-              </Suspense> */}
               <WalkingAvatar position={[0, 0.6, 0.5]} triggerSnp={triggerSnp} />
               <Sun scale={15} position={[70, 15, 30]} isCubeActive={isCubeActive} />
 
@@ -138,37 +184,35 @@ export const HomeCanvas = ({ onCubeClick }: { onCubeClick?: (clicked: boolean) =
         </Canvas>
       </div>
 
-      {(displayTheme === 'dark' || overlayOpacity > 0) && (
-        <motion.div
-          className='pointer-events-none absolute inset-0 z-10'
-          style={{
-            opacity: overlayOpacity,
-            background: `radial-gradient(circle at 50% 50%, transparent ${currentRadius}%, #000 ${currentRadius + 10}%)`,
-            transition: 'background 0.5s ease-in-out, opacity 0.4s ease-in-out',
-          }}
-        >
-          {stars.map((star) => {
-            const centerX = 50;
-            const centerY = 50;
-            const distance = Math.sqrt((star.x - centerX) ** 2 + (star.y - centerY) ** 2);
-            const minDistance = currentRadius * 0.6;
-
-            return distance > minDistance ? (
-              <div
-                key={star.id}
-                className='absolute w-0.5 h-0.5 bg-white rounded-full animate-pulse'
-                style={{
-                  left: `${star.x}%`,
-                  top: `${star.y}%`,
-                  animationDelay: `${star.delay}s`,
-                  animationDuration: `${star.duration}s`,
-                  opacity: star.opacity,
-                }}
-              />
-            ) : null;
-          })}
-        </motion.div>
-      )}
+      <div
+        ref={overlayRef}
+        className='pointer-events-none absolute inset-0 z-10'
+        style={{
+          opacity: displayTheme === 'dark' ? 1 : 0,
+          display: displayTheme === 'dark' ? 'block' : 'none',
+          background: `radial-gradient(circle at 50% 50%, transparent ${displayTheme === 'dark' ? darkRadius : lightRadius}%, #000 ${(displayTheme === 'dark' ? darkRadius : lightRadius) + 10}%)`,
+          transition: 'background 0.5s ease-in-out, opacity 0.4s ease-in-out',
+        }}
+      >
+        {stars.map((star, index) => (
+          <div
+            key={star.id}
+            ref={(el) => {
+              starNodesRef.current[index] = el;
+            }}
+            data-x={star.x}
+            data-y={star.y}
+            className='absolute w-0.5 h-0.5 bg-white rounded-full animate-pulse'
+            style={{
+              left: `${star.x}%`,
+              top: `${star.y}%`,
+              animationDelay: `${star.delay}s`,
+              animationDuration: `${star.duration}s`,
+              opacity: star.opacity,
+            }}
+          />
+        ))}
+      </div>
     </>
   );
 };

--- a/src/widgets/home/ui/WalkingAvatar.tsx
+++ b/src/widgets/home/ui/WalkingAvatar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useLayoutEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF, useFBX } from '@react-three/drei';
 import type { Group } from 'three';
@@ -11,281 +11,318 @@ type GLTFResult = GLTF & {
   skeletons: Record<string, three.Skeleton>;
 };
 
-export function WalkingAvatar(props: any & { triggerSnp?: number }) {
-  const { triggerSnp, ...restProps } = props;
+const MOVE_SPEED = 2.5;
+const WALK_CLIP_NAME = 'Armature|mixamo.com|Layer0';
+
+/** Euler(π/2, yaw, 0)는 짐벌락으로 S/A/D에서 옆으로 눕음 → 쿼터니언으로 직립+요 합성 */
+const _uprightQ = new three.Quaternion();
+const _yawQ = new three.Quaternion();
+const _axisX = new three.Vector3(1, 0, 0);
+const _axisY = new three.Vector3(0, 1, 0);
+
+const applyWalkOrientation = (avatar: Group, dx: number, dz: number) => {
+  _uprightQ.setFromAxisAngle(_axisX, Math.PI / 2);
+  _yawQ.setFromAxisAngle(_axisY, Math.atan2(dx, dz));
+  avatar.quaternion.multiplyQuaternions(_yawQ, _uprightQ);
+};
+
+/** 한글 IME에서도 동작하도록 e.code 사용. 리마운트해도 키 상태 유지 */
+const pressedCodes = new Set<string>();
+const CODE_W = 'KeyW';
+const CODE_A = 'KeyA';
+const CODE_S = 'KeyS';
+const CODE_D = 'KeyD';
+const MOVE_CODES = new Set([CODE_W, CODE_A, CODE_S, CODE_D]);
+
+let keyListenersAttached = false;
+
+const ensureKeyListeners = () => {
+  if (keyListenersAttached || typeof window === 'undefined') {
+    return;
+  }
+  keyListenersAttached = true;
+
+  window.addEventListener('keydown', (e) => {
+    if (!MOVE_CODES.has(e.code)) {
+      return;
+    }
+    e.preventDefault();
+    pressedCodes.add(e.code);
+  });
+
+  window.addEventListener('keyup', (e) => {
+    if (!MOVE_CODES.has(e.code)) {
+      return;
+    }
+    pressedCodes.delete(e.code);
+  });
+
+  window.addEventListener('blur', () => {
+    pressedCodes.clear();
+  });
+};
+
+type AvatarActions = {
+  walk: three.AnimationAction | null;
+  typing: three.AnimationAction | null;
+  snp: three.AnimationAction | null;
+};
+
+useGLTF.preload('/WalkingAstro.glb');
+useFBX.preload('/snp.fbx');
+useFBX.preload('/Typing.fbx');
+
+export function WalkingAvatar({
+  triggerSnp,
+  position = [0, 0.6, 0.5],
+  ...restProps
+}: {
+  triggerSnp?: number;
+  position?: [number, number, number];
+  [key: string]: unknown;
+}) {
   const group = useRef<Group>(null);
   const mixer = useRef<three.AnimationMixer | null>(null);
-  const { nodes, materials, animations: gltfAnimations } = useGLTF('/WalkingAstro.glb', true) as unknown as GLTFResult;
+  const actionsRef = useRef<AvatarActions>({ walk: null, typing: null, snp: null });
+  const isWalkingRef = useRef(false);
+  // React props로 position을 넘기지 않음 — 매 렌더 덮어쓰기 방지
+  const spawnRef = useRef<[number, number, number]>([
+    position[0],
+    position[1],
+    position[2],
+  ]);
+  const offsetRef = useRef(new three.Vector3(0, 0, 0));
+
+  const { nodes, materials, animations: gltfAnimations } = useGLTF(
+    '/WalkingAstro.glb',
+    true,
+  ) as unknown as GLTFResult;
   const snpModel = useFBX('/snp.fbx');
   const typingModel = useFBX('/Typing.fbx');
 
-  // 애니메이션 상태 관리
-  const [animationState, setAnimationState] = useState<'typing' | 'snp' | 'walking'>('typing');
-
-  // 애니메이션 mixer 업데이트 (필수!)
-  useFrame((_, delta) => {
-    if (mixer.current) {
-      mixer.current.update(delta);
+  useLayoutEffect(() => {
+    ensureKeyListeners();
+    if (!group.current) {
+      return;
     }
+    const [x, y, z] = spawnRef.current;
+    group.current.position.set(x, y, z);
+  }, []);
+
+  useFrame((_, delta) => {
+    mixer.current?.update(delta);
+
+    const avatar = group.current;
+    if (!avatar) {
+      return;
+    }
+
+    let dx = 0;
+    let dz = 0;
+    if (pressedCodes.has(CODE_W)) {
+      dz += 1;
+    }
+    if (pressedCodes.has(CODE_S)) {
+      dz -= 1;
+    }
+    if (pressedCodes.has(CODE_A)) {
+      dx += 1;
+    }
+    if (pressedCodes.has(CODE_D)) {
+      dx -= 1;
+    }
+
+    const isMoving = dx !== 0 || dz !== 0;
+
+    if (isMoving) {
+      const length = Math.hypot(dx, dz);
+      dx /= length;
+      dz /= length;
+
+      offsetRef.current.x += dx * MOVE_SPEED * delta;
+      offsetRef.current.z += dz * MOVE_SPEED * delta;
+      applyWalkOrientation(avatar, dx, dz);
+
+      if (!isWalkingRef.current) {
+        isWalkingRef.current = true;
+        const { walk, typing, snp } = actionsRef.current;
+        typing?.fadeOut(0.15);
+        snp?.stop();
+        if (walk) {
+          walk.reset().fadeIn(0.15).play();
+        }
+      }
+    } else if (isWalkingRef.current) {
+      isWalkingRef.current = false;
+      avatar.quaternion.identity();
+
+      const { walk, typing } = actionsRef.current;
+      walk?.fadeOut(0.15);
+      if (typing) {
+        typing.reset().fadeIn(0.15).play();
+      }
+    }
+
+    // 매 프레임 위치 강제 적용 (React/R3F props 덮어쓰기 방지)
+    const [sx, sy, sz] = spawnRef.current;
+    avatar.position.set(sx + offsetRef.current.x, sy, sz + offsetRef.current.z);
   });
 
   useEffect(() => {
-    if (group.current) {
-      // 초기 회전 설정 (서있게 만들기)
-      group.current.rotation.set(0, 0, 0);
-
-      mixer.current = new three.AnimationMixer(group.current);
-
-      // GLTF 애니메이션 설정 (걷기 애니메이션)
-      if (gltfAnimations && gltfAnimations.length > 0) {
-        for (const clip of gltfAnimations) {
-          if (clip) {
-            const action = mixer.current.clipAction(clip);
-            if (clip.name === 'Armature|mixamo.com|Layer0') {
-              action.setEffectiveTimeScale(1);
-              action.setEffectiveWeight(1);
-              action.setLoop(three.LoopRepeat, Number.POSITIVE_INFINITY);
-            }
-          }
-        }
-      }
-
-      // Typing 애니메이션 설정 및 기본 재생
-      if (typingModel.animations && typingModel.animations.length > 0 && typingModel.animations[0]) {
-        const typingAnimation = typingModel.animations[0];
-        const action = mixer.current.clipAction(typingAnimation);
-        action.setEffectiveTimeScale(1);
-        action.setEffectiveWeight(1);
-        action.setLoop(three.LoopRepeat, Number.POSITIVE_INFINITY);
-        action.play(); // 기본적으로 타이핑 애니메이션 재생
-      }
-
-      // SNP 애니메이션 설정 (재생하지 않음)
-      if (snpModel.animations && snpModel.animations.length > 0 && snpModel.animations[0]) {
-        const snpAnimation = snpModel.animations[0];
-        const action = mixer.current.clipAction(snpAnimation);
-        action.setEffectiveTimeScale(1);
-        action.setEffectiveWeight(1);
-        action.setLoop(three.LoopOnce, 1); // 한 번만 재생
-        action.clampWhenFinished = true; // 애니메이션 완료 시 마지막 프레임에서 정지
-
-        // SNP 애니메이션 완료 시 이벤트 리스너
-        mixer.current.addEventListener('finished', (e) => {
-          if (e.action === action) {
-            setAnimationState('typing'); // 타이핑으로 돌아감
-          }
-        });
-      }
-    }
-
-    return () => {
-      if (mixer.current) {
-        mixer.current.stopAllAction();
-      }
-    };
-  }, [gltfAnimations, snpModel, typingModel]);
-
-  // triggerSnp에 따른 SNP 애니메이션 트리거
-  useEffect(() => {
-    if (!mixer.current || !snpModel.animations?.[0] || !triggerSnp) {
+    if (!group.current) {
       return;
     }
 
-    const snpAction = mixer.current.clipAction(snpModel.animations[0]);
-    const typingAction = typingModel.animations?.[0] ? mixer.current.clipAction(typingModel.animations[0]) : null;
+    const currentMixer = new three.AnimationMixer(group.current);
+    mixer.current = currentMixer;
 
-    // 타이핑 애니메이션 정지하고 SNP 애니메이션 재생
-    if (typingAction) {
-      typingAction.stop();
-    }
-    snpAction.reset();
-    snpAction.play();
-    setAnimationState('snp');
-  }, [triggerSnp, snpModel, typingModel]);
-
-  // 애니메이션 상태에 따른 애니메이션 제어
-  useEffect(() => {
-    if (!mixer.current) {
-      return;
+    const walkClip = gltfAnimations?.find((clip) => clip?.name === WALK_CLIP_NAME);
+    if (walkClip) {
+      const walkAction = currentMixer.clipAction(walkClip);
+      walkAction.setEffectiveTimeScale(1);
+      walkAction.setEffectiveWeight(1);
+      walkAction.setLoop(three.LoopRepeat, Number.POSITIVE_INFINITY);
+      actionsRef.current.walk = walkAction;
     }
 
-    const typingAction = typingModel.animations?.[0] ? mixer.current.clipAction(typingModel.animations[0]) : null;
-    const snpAction = snpModel.animations?.[0] ? mixer.current.clipAction(snpModel.animations[0]) : null;
-
-    if (animationState === 'typing' && typingAction) {
-      // 다른 애니메이션 정지하고 타이핑 시작
-      if (snpAction) {
-        snpAction.stop();
-      }
-      typingAction.reset();
+    const typingClip = typingModel.animations?.[0];
+    if (typingClip) {
+      const typingAction = currentMixer.clipAction(typingClip);
+      typingAction.setEffectiveTimeScale(1);
+      typingAction.setEffectiveWeight(1);
+      typingAction.setLoop(three.LoopRepeat, Number.POSITIVE_INFINITY);
       typingAction.play();
+      actionsRef.current.typing = typingAction;
     }
-  }, [animationState, typingModel, snpModel]);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!group.current || !mixer.current) {
-        return;
-      }
+    const snpClip = snpModel.animations?.[0];
+    let onFinished: ((e: { action: three.AnimationAction }) => void) | undefined;
 
-      const speed = 0.08;
-      const key = e.key.toLowerCase();
+    if (snpClip) {
+      const snpAction = currentMixer.clipAction(snpClip);
+      snpAction.setEffectiveTimeScale(1);
+      snpAction.setEffectiveWeight(1);
+      snpAction.setLoop(three.LoopOnce, 1);
+      snpAction.clampWhenFinished = true;
+      actionsRef.current.snp = snpAction;
 
-      // 걷기 상태로 변경
-      setAnimationState('walking');
-
-      // 걷기 애니메이션 재생
-      const walkingClip = gltfAnimations?.find((clip) => clip && clip.name === 'Armature|mixamo.com|Layer0');
-      if (walkingClip) {
-        const walkAction = mixer.current.clipAction(walkingClip);
-        if (walkAction && !walkAction.isRunning()) {
-          // 다른 애니메이션 정지
-          const typingAction = typingModel.animations?.[0] ? mixer.current.clipAction(typingModel.animations[0]) : null;
-          const snpAction = snpModel.animations?.[0] ? mixer.current.clipAction(snpModel.animations[0]) : null;
-          if (typingAction) {
-            typingAction.stop();
-          }
-          if (snpAction) {
-            snpAction.stop();
-          }
-
-          walkAction.play();
+      onFinished = (e) => {
+        if (e.action !== snpAction || isWalkingRef.current) {
+          return;
         }
-      }
-
-      switch (key) {
-        case 'w':
-          group.current.position.z += speed;
-          group.current.rotation.set(Math.PI / 2, 0, 0);
-          break;
-        case 's':
-          group.current.position.z -= speed;
-          group.current.rotation.set(-Math.PI / 2, Math.PI, 0);
-          break;
-        case 'a':
-          group.current.position.x += speed;
-          group.current.rotation.set(-Math.PI / 2, Math.PI, Math.PI / 2);
-          break;
-        case 'd':
-          group.current.position.x -= speed;
-          group.current.rotation.set(-Math.PI / 2, Math.PI, -Math.PI / 2);
-          break;
-      }
-    };
-
-    const handleKeyUp = () => {
-      if (!mixer.current) {
-        return;
-      }
-
-      // 원래 회전 상태로 복귀
-      if (group.current) {
-        group.current.rotation.set(0, 0, 0);
-      }
-
-      // 걷기 애니메이션 정지
-      const walkingClip = gltfAnimations?.find((clip) => clip && clip.name === 'Armature|mixamo.com|Layer0');
-      if (walkingClip) {
-        const walkAction = mixer.current.clipAction(walkingClip);
-        if (walkAction) {
-          walkAction.stop();
-        }
-      }
-
-      // 타이핑 상태로 복귀
-      setAnimationState('typing');
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
+        actionsRef.current.typing?.reset().fadeIn(0.2).play();
+      };
+      currentMixer.addEventListener('finished', onFinished);
+    }
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
+      if (onFinished) {
+        currentMixer.removeEventListener('finished', onFinished);
+      }
+      currentMixer.stopAllAction();
+      if (mixer.current === currentMixer) {
+        mixer.current = null;
+      }
+      actionsRef.current = { walk: null, typing: null, snp: null };
     };
-  }, [gltfAnimations, typingModel, snpModel]);
+    // FBX/GLTF 객체 identity가 매 렌더 바뀌지 않도록 클립 존재 여부만 의존
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
+  }, [gltfAnimations, typingModel.animations, snpModel.animations]);
+
+  useEffect(() => {
+    if (!triggerSnp || isWalkingRef.current) {
+      return;
+    }
+
+    const { snp, typing, walk } = actionsRef.current;
+    if (!snp) {
+      return;
+    }
+
+    typing?.fadeOut(0.1);
+    walk?.stop();
+    snp.reset().fadeIn(0.1).play();
+  }, [triggerSnp]);
 
   return (
     <group ref={group} {...restProps} dispose={null}>
-      <group>
-        <group name='RootNode'>
-          <group name='67359760e8bd414fac2378ecfb5ba5c5fbx' rotation={[0, 0, 0]}>
-            <group name='RootNode1'>
-              <group name='left' position={[-100.1, 0, 0]}>
-                <group name='Object_4' />
-              </group>
-              <group name='group1'>
-                <group name='broche_nino'>
-                  <skinnedMesh
-                    name='broche_nino_cremayera_t_0'
-                    geometry={nodes.broche_nino_cremayera_t_0?.geometry}
-                    material={materials.cremayera_t}
-                    skeleton={nodes.broche_nino_cremayera_t_0?.skeleton}
-                  />
-                </group>
-                <group name='Casco_nino'>
-                  <skinnedMesh
-                    name='Casco_nino_casco_nino_m_0'
-                    geometry={nodes.Casco_nino_casco_nino_m_0?.geometry}
-                    material={materials.casco_nino_m}
-                    skeleton={nodes.Casco_nino_casco_nino_m_0?.skeleton}
-                  />
-                </group>
-                <group name='botas_nino'>
-                  <group name='pie_n_der'>
-                    <skinnedMesh
-                      name='pie_n_der_botas_nino_m_0'
-                      geometry={nodes.pie_n_der_botas_nino_m_0?.geometry}
-                      material={materials.botas_nino_m}
-                      skeleton={nodes.pie_n_der_botas_nino_m_0?.skeleton}
-                    />
-                  </group>
-                  <group name='pie_n_izq'>
-                    <skinnedMesh
-                      name='pie_n_izq_botas_nino_m_0'
-                      geometry={nodes.pie_n_izq_botas_nino_m_0?.geometry}
-                      material={materials.botas_nino_m}
-                      skeleton={nodes.pie_n_izq_botas_nino_m_0?.skeleton}
-                    />
-                  </group>
-                </group>
-              </group>
-              <group name='pasted__Lente_nino'>
+      <group name='RootNode'>
+        <group name='67359760e8bd414fac2378ecfb5ba5c5fbx' rotation={[0, 0, 0]}>
+          <group name='RootNode1'>
+            <group name='left' position={[-100.1, 0, 0]}>
+              <group name='Object_4' />
+            </group>
+            <group name='group1'>
+              <group name='broche_nino'>
                 <skinnedMesh
-                  name='pasted__Lente_nino_pasted__vidrio_astr_nina_0'
-                  geometry={nodes.pasted__Lente_nino_pasted__vidrio_astr_nina_0?.geometry}
-                  material={materials.pasted__vidrio_astr_nina}
-                  skeleton={nodes.pasted__Lente_nino_pasted__vidrio_astr_nina_0?.skeleton}
+                  name='broche_nino_cremayera_t_0'
+                  geometry={nodes.broche_nino_cremayera_t_0?.geometry}
+                  material={materials.cremayera_t}
+                  skeleton={nodes.broche_nino_cremayera_t_0?.skeleton}
                 />
               </group>
-              <group name='pasted__Traje_nino'>
-                <group name='polySurface3'>
+              <group name='Casco_nino'>
+                <skinnedMesh
+                  name='Casco_nino_casco_nino_m_0'
+                  geometry={nodes.Casco_nino_casco_nino_m_0?.geometry}
+                  material={materials.casco_nino_m}
+                  skeleton={nodes.Casco_nino_casco_nino_m_0?.skeleton}
+                />
+              </group>
+              <group name='botas_nino'>
+                <group name='pie_n_der'>
                   <skinnedMesh
-                    name='polySurface3_pasted__trajechico_0'
-                    geometry={nodes.polySurface3_pasted__trajechico_0?.geometry}
-                    material={materials.pasted__trajechico}
-                    skeleton={nodes.polySurface3_pasted__trajechico_0?.skeleton}
-                  />
-                  <skinnedMesh
-                    name='polySurface3_pasted__logonino_0'
-                    geometry={nodes.polySurface3_pasted__logonino_0?.geometry}
-                    material={materials.pasted__logonino}
-                    skeleton={nodes.polySurface3_pasted__logonino_0?.skeleton}
+                    name='pie_n_der_botas_nino_m_0'
+                    geometry={nodes.pie_n_der_botas_nino_m_0?.geometry}
+                    material={materials.botas_nino_m}
+                    skeleton={nodes.pie_n_der_botas_nino_m_0?.skeleton}
                   />
                 </group>
-                <group name='polySurface4'>
+                <group name='pie_n_izq'>
                   <skinnedMesh
-                    name='polySurface4_pasted__trajechico_0'
-                    geometry={nodes.polySurface4_pasted__trajechico_0?.geometry}
-                    material={materials.pasted__trajechico}
-                    skeleton={nodes.polySurface4_pasted__trajechico_0?.skeleton}
+                    name='pie_n_izq_botas_nino_m_0'
+                    geometry={nodes.pie_n_izq_botas_nino_m_0?.geometry}
+                    material={materials.botas_nino_m}
+                    skeleton={nodes.pie_n_izq_botas_nino_m_0?.skeleton}
                   />
                 </group>
               </group>
             </group>
+            <group name='pasted__Lente_nino'>
+              <skinnedMesh
+                name='pasted__Lente_nino_pasted__vidrio_astr_nina_0'
+                geometry={nodes.pasted__Lente_nino_pasted__vidrio_astr_nina_0?.geometry}
+                material={materials.pasted__vidrio_astr_nina}
+                skeleton={nodes.pasted__Lente_nino_pasted__vidrio_astr_nina_0?.skeleton}
+              />
+            </group>
+            <group name='pasted__Traje_nino'>
+              <group name='polySurface3'>
+                <skinnedMesh
+                  name='polySurface3_pasted__trajechico_0'
+                  geometry={nodes.polySurface3_pasted__trajechico_0?.geometry}
+                  material={materials.pasted__trajechico}
+                  skeleton={nodes.polySurface3_pasted__trajechico_0?.skeleton}
+                />
+                <skinnedMesh
+                  name='polySurface3_pasted__logonino_0'
+                  geometry={nodes.polySurface3_pasted__logonino_0?.geometry}
+                  material={materials.pasted__logonino}
+                  skeleton={nodes.polySurface3_pasted__logonino_0?.skeleton}
+                />
+              </group>
+              <group name='polySurface4'>
+                <skinnedMesh
+                  name='polySurface4_pasted__trajechico_0'
+                  geometry={nodes.polySurface4_pasted__trajechico_0?.geometry}
+                  material={materials.pasted__trajechico}
+                  skeleton={nodes.polySurface4_pasted__trajechico_0?.skeleton}
+                />
+              </group>
+            </group>
           </group>
-          <primitive object={nodes.mixamorigHips as unknown as three.Object3D} />
         </group>
+        <primitive object={nodes.mixamorigHips as unknown as three.Object3D} />
       </group>
     </group>
   );


### PR DESCRIPTION
## Summary
- WalkingAvatar WASD를 `e.code` + `useFrame` 연속 이동으로 고치고, 직립/요를 쿼터니언으로 합성해 S/A/D에서 눕는 문제 해결
- HomeCanvas 테마 오버레이의 매 프레임 `setState`를 DOM 갱신으로 바꿔 아바타 위치 리셋 방지
- CanvasLoader `useProgress` 제거로 로드 중 렌더 `setState` 충돌 방지

## Test plan
- [ ] 라이트 모드 홈에서 캔버스 포커스 후 WASD로 우주인이 서서 네 방향 이동하는지 확인
- [ ] 한글 입력 모드(IME)에서도 WASD가 동작하는지 확인
- [ ] 키를 떼면 typing 자세로 복귀하는지 확인
- [ ] 다크/라이트 테마 전환 오버레이가 기존처럼 동작하는지 확인
- [ ] 콘솔에 CanvasLoader/WalkingAvatar setState 경고가 없는지 확인


Made with [Cursor](https://cursor.com)