### PR TITLE
feat: 블로그 (posts) 코스모스 라이트/다크 UI

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/page.tsx
@@ -1,19 +1,26 @@
 'use client';
 
+import { useParams } from 'next/navigation';
 import { PostListCard } from '@/features/blog/ui';
 import { useCategoryPosts } from '@/features/category/model';
-import { useParams } from 'next/navigation';
+import { PostListCardSkeleton } from '@/shared/ui/skeleton';
 
 export default function BlogPostPage() {
   const { slug } = useParams();
   const { data: categoryPosts, isLoading: isCategoryPostsLoading } = useCategoryPosts(slug as string, 1, 10);
 
   if (isCategoryPostsLoading) {
-    return <div>Loading...</div>;
+    return (
+      <div className='mx-auto flex w-full max-w-4xl flex-col gap-8' aria-busy='true'>
+        {['a', 'b', 'c', 'd', 'e'].map((id) => (
+          <PostListCardSkeleton key={`category-skeleton-${id}`} />
+        ))}
+      </div>
+    );
   }
 
   return (
-    <div className='max-w-4xl mx-auto w-full'>
+    <div className='mx-auto w-full max-w-4xl'>
       {categoryPosts?.posts?.map((post) => (
         <PostListCard key={post.id} post={post} categoryName={categoryPosts?.name} categorySlug={categoryPosts?.slug} />
       ))}

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/loading.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/loading.tsx
@@ -1,27 +1,26 @@
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
 export default function PostDetailLoading() {
   return (
-    <div
-      className='max-w-4xl mx-4 lg:mx-auto mt-4 mb-12'
-      aria-busy='true'
-      aria-label='포스트 불러오는 중'
-    >
-      <section className='relative md:bg-gradient-to-br md:from-[#181c2a]/90 md:via-[#232946]/90 md:to-[#232946]/80 md:border md:border-blue-400/30 md:rounded-2xl md:shadow-[0_0_24px_4px_#7dd3fc22] px-4 sm:px-6 md:px-8 py-8 overflow-hidden'>
+    <div className='mx-4 mb-12 mt-4 max-w-4xl lg:mx-auto' aria-busy='true'>
+      <section className={`relative overflow-hidden px-4 py-8 sm:px-6 md:rounded-2xl md:px-8 ${blogTheme.postSection}`}>
+        <span className={blogTheme.cardTopGlow} aria-hidden />
         <div className='space-y-4'>
-          <div className='h-9 w-3/4 max-w-xl rounded-lg bg-blue-400/20 animate-pulse' />
+          <div className='h-9 w-3/4 max-w-xl animate-pulse rounded-lg bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
           <div className='flex items-center gap-3'>
-            <div className='h-3 w-20 rounded bg-blue-400/15 animate-pulse' />
-            <div className='h-3 w-24 rounded bg-blue-400/15 animate-pulse' />
-            <div className='h-3 w-16 rounded bg-blue-400/15 animate-pulse' />
+            <div className='h-3 w-20 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-3 w-24 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-3 w-16 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
           </div>
           <div className='flex flex-wrap gap-2 pt-2'>
-            <div className='h-6 w-14 rounded-full bg-blue-500/20 animate-pulse' />
-            <div className='h-6 w-16 rounded-full bg-blue-500/20 animate-pulse' />
-            <div className='h-6 w-12 rounded-full bg-blue-500/20 animate-pulse' />
+            <div className='h-6 w-14 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+            <div className='h-6 w-16 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+            <div className='h-6 w-12 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
           </div>
-          <div className='mt-6 space-y-3 rounded-xl border border-blue-400/20 bg-[#181c2a]/40 p-4'>
-            <div className='h-4 w-24 rounded bg-cyan-400/20 animate-pulse' />
-            <div className='h-3 w-full rounded bg-blue-400/15 animate-pulse' />
-            <div className='h-3 w-5/6 rounded bg-blue-400/15 animate-pulse' />
+          <div className={`mt-6 space-y-3 p-4 ${blogTheme.summaryBox}`}>
+            <div className='h-4 w-24 animate-pulse rounded bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+            <div className='h-3 w-full animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-3 w-5/6 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
           </div>
           <div className='mt-8 space-y-3'>
             {['w88-1', 'w76-1', 'w64-1', 'w52-1', 'w88-2', 'w76-2', 'w64-2', 'w52-2'].map((id) => {
@@ -29,7 +28,7 @@ export default function PostDetailLoading() {
               return (
                 <div
                   key={id}
-                  className='h-4 rounded bg-blue-400/15 animate-pulse'
+                  className='h-4 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15'
                   style={{ width: `${width}%` }}
                 />
               );

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -147,6 +147,10 @@ export default async function PostPage({
     notFound();
   }
 
+  if (post.category?.slug && post.category.slug !== categorySlug) {
+    notFound();
+  }
+
   const backHref = `/blog/category/${post.category?.slug ?? categorySlug}`;
 
   return (

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -5,6 +5,9 @@ import { CommentSection } from '@/features/comment/ui';
 import { PostSummary } from '@/shared/ui/PostSummary';
 import type { Metadata } from 'next';
 import type { PostResponse } from '@/entities/post/model/post';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
+import { notFound } from 'next/navigation';
 
 const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'));
 
@@ -24,9 +27,10 @@ const extractDescription = (content: string, maxLength = 160) => {
 export async function generateMetadata({ params }: { params: Promise<{ postSlug: string }> }): Promise<Metadata> {
   const { postSlug } = await params;
   const decodedSlug = decodeURIComponent(postSlug);
-  const post = await getPostBySlug(decodedSlug);
 
-  const description = extractDescription(post.content ?? '');
+  try {
+    const post = await getPostBySlug(decodedSlug);
+    const description = extractDescription(post.content ?? '');
   const publishedDate = post.createdAt ? new Date(post.createdAt).toISOString() : '';
   const modifiedDate = post.updatedAt ? new Date(post.updatedAt).toISOString() : publishedDate;
   const postUrl = `${process.env.NEXT_PUBLIC_APP_URL}/blog/category/${post.category?.slug || 'uncategorized'}/post/${postSlug}`;
@@ -77,6 +81,11 @@ export async function generateMetadata({ params }: { params: Promise<{ postSlug:
       canonical: postUrl,
     },
   };
+  } catch {
+    return {
+      title: 'Post not found',
+    };
+  }
 }
 
 // JSON-LD 구조화 데이터 컴포넌트
@@ -121,50 +130,61 @@ const PostStructuredData = ({
 export default async function PostPage({
   params,
 }: {
-  params: Promise<{ postSlug: string }>;
+  params: Promise<{ slug: string; postSlug: string }>;
 }) {
-  const { postSlug } = await params;
+  const { slug, postSlug } = await params;
   const decodedSlug = decodeURIComponent(postSlug);
-  const post = await getPostBySlug(decodedSlug);
+  const categorySlug = decodeURIComponent(slug);
 
-  if (!post || !post.title || !post.content) {
-    return <div>Post not found</div>;
+  let post: PostResponse;
+  try {
+    post = await getPostBySlug(decodedSlug);
+  } catch {
+    notFound();
   }
+
+  if (!post?.title || !post?.content) {
+    notFound();
+  }
+
+  const backHref = `/blog/category/${post.category?.slug ?? categorySlug}`;
 
   return (
     <>
       {/* SEO를 위한 구조화 데이터 */}
       <PostStructuredData post={post} />
 
-      <div>
+      <div className='mx-4 max-w-4xl lg:mx-auto'>
+        <PostBackButton href={backHref} />
+
         {/* 본문 영역 꾸밈 */}
-        <section className='relative md:bg-gradient-to-br md:from-[#181c2a]/90 md:via-[#232946]/90 md:to-[#232946]/80 md:border md:border-blue-400/30 md:rounded-2xl md:shadow-[0_0_24px_4px_#7dd3fc22] px-4 sm:px-6 md:px-8 py-8 mb-12 mt-4 max-w-4xl mx-4 md:overflow-hidden lg:mx-auto'>
-          <div className='absolute inset-0 pointer-events-none z-0 hidden md:block'>
-            <div className='w-full h-full bg-gradient-to-tr from-blue-900/20 via-fuchsia-900/10 to-blue-800/10 blur-[2px]' />
+        <section
+          className={`relative mb-12 mt-0 px-4 py-8 sm:px-6 md:rounded-2xl md:px-8 md:overflow-hidden ${blogTheme.postSection}`}
+        >
+          <div className='pointer-events-none absolute inset-0 z-0 hidden md:block'>
+            <div className='h-full w-full bg-gradient-to-tr from-[#8a4a68]/15 via-[#1c0e38]/20 to-[#ffc090]/10 blur-[2px] dark:from-cyan-900/20 dark:via-fuchsia-900/10 dark:to-cyan-800/10' />
           </div>
-          <h1 className='relative z-10 text-3xl font-extrabold text-blue-100 mb-4 md:drop-shadow-[0_2px_8px_#7dd3fc55]'>
+          <h1
+            className={`relative z-10 mb-4 text-3xl font-extrabold md:drop-shadow-sm dark:md:drop-shadow-[0_2px_8px_#7dd3fc55] ${blogTheme.textPrimary}`}
+          >
             {post.title}
           </h1>
-          <div className='relative z-10 flex items-center gap-3 mb-6 text-xs text-blue-200'>
+          <div className={`relative z-10 mb-6 flex items-center gap-3 text-xs ${blogTheme.textMuted}`}>
             <span className='font-mono'>{post.author?.name || 'Unknown Author'}</span>
             <span className='opacity-60'>|</span>
             <span>{formatDateToYMD(post?.createdAt ?? '')}</span>
             {post.category && (
               <>
                 <span className='opacity-60'>|</span>
-                <span className='text-blue-300'>{post.category.name}</span>
+                <span className={blogTheme.textAccent}>{post.category.name}</span>
               </>
             )}
           </div>
 
-          {/* 태그 표시 */}
           {post.tags && post.tags.length > 0 && (
-            <div className='relative z-10 flex flex-wrap gap-2 mb-6'>
-              {post.tags.map((tag: any) => (
-                <span
-                  key={tag.id}
-                  className='px-3 py-1 text-xs bg-blue-500/20 text-blue-200 rounded-full border border-blue-400/30'
-                >
+            <div className='relative z-10 mb-6 flex flex-wrap gap-2'>
+              {post.tags.map((tag) => (
+                <span key={tag.id} className={blogTheme.tagPill}>
                   #{tag.name}
                 </span>
               ))}
@@ -181,7 +201,6 @@ export default async function PostPage({
           </div>
         </section>
 
-        {/* 댓글 섹션 */}
         <CommentSection postId={post.id ?? 0} />
       </div>
     </>

--- a/app/(public)/blog/(posts)/layout.tsx
+++ b/app/(public)/blog/(posts)/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { PostsLayoutShell } from '@/widgets/post/ui/PostsLayoutShell';
+import { PostsLayoutShell } from '@/widgets/post/ui';
 
 export const metadata: Metadata = {
   title: 'Blog',

--- a/app/(public)/blog/(posts)/layout.tsx
+++ b/app/(public)/blog/(posts)/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
-import { SpaceBackground } from '@/widgets/post/ui';
-import BlogHeader from '@/widgets/post/ui/BlogHeader';
-import Sidebar from '@/widgets/post/ui/Sidebar';
+import { PostsLayoutShell } from '@/widgets/post/ui/PostsLayoutShell';
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -10,28 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function PostsLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <main className='flex flex-col items-center row-start-2 gap-8 sm:items-start bg-white min-h-screen'>
-      <div className='w-full h-screen overflow-hidden bg-gradient-to-b from-[#181c2a] via-[#232946] to-[#23234d] text-slate-100 font-mono relative'>
-        <SpaceBackground />
-
-        <div className='flex h-screen'>
-          {/* Main Content (왼쪽) */}
-          <main className='flex-1 h-screen overflow-y-auto p-4 lg:p-10 flex justify-center'>
-            <div className='w-full'>
-              <Suspense fallback={<div className='mb-8 h-16 max-w-4xl mx-auto w-full' />}>
-                <BlogHeader />
-              </Suspense>
-              {children}
-            </div>
-          </main>
-
-          {/* 데스크톱 사이드바 */}
-          <Suspense fallback={null}>
-            <Sidebar />
-          </Suspense>
-        </div>
-      </div>
-    </main>
-  );
+  return <PostsLayoutShell>{children}</PostsLayoutShell>;
 }

--- a/app/api/posts/[slug]/route.ts
+++ b/app/api/posts/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import prisma from '@/shared/lib/db';
 
 /**
@@ -193,39 +194,54 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
     // IP당 24시간 내 중복 조회 체크 (PostView는 postId+ip 유니크)
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    const existingView = await prisma.postView.findUnique({
-      where: {
-        postId_ip: {
-          postId: post.id,
-          ip: clientIP,
-        },
-      },
-    });
+    try {
+      await prisma.$transaction(async (tx) => {
+        const existingView = await tx.postView.findUnique({
+          where: {
+            postId_ip: {
+              postId: post.id,
+              ip: clientIP,
+            },
+          },
+        });
 
-    const shouldCountView = !existingView || existingView.createdAt < twentyFourHoursAgo;
+        if (existingView && existingView.createdAt >= twentyFourHoursAgo) {
+          return;
+        }
 
-    if (shouldCountView) {
-      await prisma.$transaction([
-        prisma.post.update({
+        await tx.post.update({
           where: { id: post.id },
           data: { views: { increment: 1 } },
-        }),
-        existingView
-          ? prisma.postView.update({
-              where: { id: existingView.id },
-              data: {
-                createdAt: new Date(),
-                userAgent,
-              },
-            })
-          : prisma.postView.create({
-              data: {
-                postId: post.id,
-                ip: clientIP,
-                userAgent,
-              },
-            }),
-      ]);
+        });
+
+        await tx.postView.upsert({
+          where: {
+            postId_ip: {
+              postId: post.id,
+              ip: clientIP,
+            },
+          },
+          create: {
+            postId: post.id,
+            ip: clientIP,
+            userAgent,
+          },
+          update: {
+            createdAt: new Date(),
+            userAgent,
+          },
+        });
+      });
+    } catch (error) {
+      // 동시 요청 레이스는 무시 (한 요청만 조회수 반영)
+      if (
+        !(
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          (error.code === 'P2002' || error.code === 'P2034')
+        )
+      ) {
+        throw error;
+      }
     }
 
     // 조회수 업데이트된 게시물 정보 반환

--- a/app/api/posts/[slug]/route.ts
+++ b/app/api/posts/[slug]/route.ts
@@ -190,35 +190,41 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
       return NextResponse.json({ error: 'Post not found' }, { status: 404 });
     }
 
-    // 24시간 내 중복 조회 체크
+    // IP당 24시간 내 중복 조회 체크 (PostView는 postId+ip 유니크)
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    const existingView = await prisma.postView.findFirst({
+    const existingView = await prisma.postView.findUnique({
       where: {
-        postId: post.id,
-        ip: clientIP,
-        createdAt: {
-          gte: twentyFourHoursAgo,
+        postId_ip: {
+          postId: post.id,
+          ip: clientIP,
         },
       },
     });
 
-    // 중복 조회가 아닌 경우에만 조회수 증가 및 기록 저장
-    if (!existingView) {
+    const shouldCountView = !existingView || existingView.createdAt < twentyFourHoursAgo;
+
+    if (shouldCountView) {
       await prisma.$transaction([
-        // 조회수 증가
         prisma.post.update({
           where: { id: post.id },
           data: { views: { increment: 1 } },
         }),
-        // 조회 기록 저장
-        prisma.postView.create({
-          data: {
-            postId: post.id,
-            ip: clientIP,
-            userAgent: userAgent,
-          },
-        }),
+        existingView
+          ? prisma.postView.update({
+              where: { id: existingView.id },
+              data: {
+                createdAt: new Date(),
+                userAgent,
+              },
+            })
+          : prisma.postView.create({
+              data: {
+                postId: post.id,
+                ip: clientIP,
+                userAgent,
+              },
+            }),
       ]);
     }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -566,3 +566,108 @@ pre {
 .ProseMirror .highlight.orange {
   background: rgba(249, 115, 22, 0.2);
 }
+
+/* Blog post prose — light: warm twilight / dark: cool deep space */
+.blog-prose .ProseMirror {
+  color: #ffe8d0;
+}
+
+.blog-prose .ProseMirror h1,
+.blog-prose .ProseMirror h2,
+.blog-prose .ProseMirror h3 {
+  color: #ffc8a0;
+}
+
+.blog-prose .ProseMirror p,
+.blog-prose .ProseMirror ul,
+.blog-prose .ProseMirror ol {
+  color: #ffe8d0;
+}
+
+.blog-prose .ProseMirror strong {
+  color: #ffb870;
+}
+
+.blog-prose .ProseMirror em {
+  color: #d4a8c0;
+}
+
+.blog-prose .ProseMirror a {
+  color: #ff9a3c;
+}
+
+.blog-prose .ProseMirror a:hover {
+  color: #ffc8a0;
+}
+
+.blog-prose .ProseMirror blockquote {
+  border-left-color: rgba(255, 154, 60, 0.45);
+  color: #d4a8c0;
+  background: rgba(255, 154, 60, 0.08);
+}
+
+.blog-prose .ProseMirror code {
+  color: #ffc8a0;
+  background: rgba(255, 154, 60, 0.15);
+}
+
+.blog-prose .ProseMirror pre {
+  background: #1c0e38;
+  border-color: rgba(255, 154, 60, 0.3);
+}
+
+.blog-prose .ProseMirror pre code {
+  color: #ffe8d0;
+}
+
+.dark .blog-prose .ProseMirror {
+  color: #c8e8ff;
+}
+
+.dark .blog-prose .ProseMirror h1,
+.dark .blog-prose .ProseMirror h2,
+.dark .blog-prose .ProseMirror h3 {
+  color: #e8f4ff;
+}
+
+.dark .blog-prose .ProseMirror p,
+.dark .blog-prose .ProseMirror ul,
+.dark .blog-prose .ProseMirror ol {
+  color: #c8e8ff;
+}
+
+.dark .blog-prose .ProseMirror strong {
+  color: #3de8ff;
+}
+
+.dark .blog-prose .ProseMirror em {
+  color: #7ec8ff;
+}
+
+.dark .blog-prose .ProseMirror a {
+  color: #3de8ff;
+}
+
+.dark .blog-prose .ProseMirror a:hover {
+  color: #7ec8ff;
+}
+
+.dark .blog-prose .ProseMirror blockquote {
+  border-left-color: rgba(61, 232, 255, 0.4);
+  color: #7ec8ff;
+  background: rgba(61, 232, 255, 0.06);
+}
+
+.dark .blog-prose .ProseMirror code {
+  color: #7ec8ff;
+  background: rgba(61, 232, 255, 0.12);
+}
+
+.dark .blog-prose .ProseMirror pre {
+  background: #070414;
+  border-color: rgba(61, 232, 255, 0.25);
+}
+
+.dark .blog-prose .ProseMirror pre code {
+  color: #c8e8ff;
+}

--- a/src/features/blog/ui/PostCard/CardPattern.tsx
+++ b/src/features/blog/ui/PostCard/CardPattern.tsx
@@ -15,12 +15,33 @@ const coolGradients = [
   'bg-gradient-to-r from-teal-500 via-cyan-400 to-blue-600',
 ];
 
-export const CardPattern = ({ mouseX, mouseY }: { mouseX: MotionValue<number>; mouseY: MotionValue<number> }) => {
+const hashSeed = (seed: string) => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = seed.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash);
+};
+
+type CardPatternProps = {
+  mouseX: MotionValue<number>;
+  mouseY: MotionValue<number>;
+  seed?: string | number;
+};
+
+export const CardPattern = ({ mouseX, mouseY, seed = 'card' }: CardPatternProps) => {
   const maskImage = useMotionTemplate`radial-gradient(250px at ${mouseX}px ${mouseY}px, white, transparent)`;
   const style = { maskImage, WebkitMaskImage: maskImage };
+  const seedKey = String(seed);
 
-  const warmGradient = useMemo(() => warmGradients[Math.floor(Math.random() * warmGradients.length)], []);
-  const coolGradient = useMemo(() => coolGradients[Math.floor(Math.random() * coolGradients.length)], []);
+  const warmGradient = useMemo(
+    () => warmGradients[hashSeed(`${seedKey}-warm`) % warmGradients.length],
+    [seedKey],
+  );
+  const coolGradient = useMemo(
+    () => coolGradients[hashSeed(`${seedKey}-cool`) % coolGradients.length],
+    [seedKey],
+  );
 
   return (
     <div className='pointer-events-none'>

--- a/src/features/blog/ui/PostCard/CardPattern.tsx
+++ b/src/features/blog/ui/PostCard/CardPattern.tsx
@@ -1,71 +1,38 @@
 import { motion, useMotionTemplate, type MotionValue } from 'framer-motion';
 import { useMemo } from 'react';
 
+const warmGradients = [
+  'bg-gradient-to-r from-orange-500 via-amber-400 to-rose-500',
+  'bg-gradient-to-r from-rose-500 via-orange-400 to-yellow-400',
+  'bg-gradient-to-r from-fuchsia-500 via-orange-400 to-amber-300',
+  'bg-gradient-to-r from-amber-500 via-rose-400 to-orange-600',
+];
+
+const coolGradients = [
+  'bg-gradient-to-r from-cyan-500 via-blue-500 to-indigo-600',
+  'bg-gradient-to-r from-blue-600 via-cyan-400 to-violet-600',
+  'bg-gradient-to-r from-indigo-500 via-cyan-500 to-blue-700',
+  'bg-gradient-to-r from-teal-500 via-cyan-400 to-blue-600',
+];
+
 export const CardPattern = ({ mouseX, mouseY }: { mouseX: MotionValue<number>; mouseY: MotionValue<number> }) => {
   const maskImage = useMotionTemplate`radial-gradient(250px at ${mouseX}px ${mouseY}px, white, transparent)`;
   const style = { maskImage, WebkitMaskImage: maskImage };
 
-  // 여러 색상 조합 중 하나를 랜덤으로 선택
-  const gradientClasses = [
-    'bg-gradient-to-r from-blue-500 via-cyan-400 to-blue-700',
-    'bg-gradient-to-r from-blue-700 via-purple-500 to-cyan-400',
-    'bg-gradient-to-r from-blue-900 via-blue-500 to-cyan-300',
-    'bg-gradient-to-r from-cyan-400 via-blue-400 to-blue-800',
-    'bg-gradient-to-r from-blue-600 via-sky-400 to-cyan-500',
-    'bg-gradient-to-r from-pink-400 via-yellow-300 to-cyan-400',
-    'bg-gradient-to-r from-fuchsia-400 via-orange-300 to-yellow-300',
-    'bg-gradient-to-r from-emerald-400 via-cyan-300 to-blue-400',
-    'bg-gradient-to-r from-yellow-300 via-pink-400 to-fuchsia-500',
-    'bg-gradient-to-r from-red-400 via-orange-300 to-yellow-300',
-    'bg-gradient-to-r from-lime-300 via-emerald-400 to-cyan-400',
-    'bg-gradient-to-r from-pink-400 via-blue-400 to-cyan-300',
-    'bg-gradient-to-r from-orange-400 via-yellow-300 to-lime-300',
-    'bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400',
-  ];
-  const gradientClass = useMemo(() => {
-    return gradientClasses[Math.floor(Math.random() * gradientClasses.length)];
-  }, []);
-
-  // 별 30개 랜덤 생성 (key는 uuid)
-  const stars = Array.from({ length: 30 }).map(() => {
-    const size = Math.random() * 1.2 + 0.6; // 0.6~1.8rem
-    const top = `${Math.random() * 100}%`;
-    const left = `${Math.random() * 100}%`;
-    const opacity = 0.3 + Math.random() * 0.7;
-    const rotate = Math.random() * 360;
-    const key = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2);
-    return (
-      <span
-        key={key}
-        style={{
-          position: 'absolute',
-          top,
-          left,
-          fontSize: `${size}rem`,
-          opacity,
-          color: '#fff',
-          filter: 'drop-shadow(0 0 4px #7dd3fc88)',
-          transform: `rotate(${rotate}deg)`,
-        }}
-      >
-        ★
-      </span>
-    );
-  });
+  const warmGradient = useMemo(() => warmGradients[Math.floor(Math.random() * warmGradients.length)], []);
+  const coolGradient = useMemo(() => coolGradients[Math.floor(Math.random() * coolGradients.length)], []);
 
   return (
     <div className='pointer-events-none'>
-      <div className='absolute inset-0 z-10 rounded-2xl  [mask-image:linear-gradient(white,transparent)] group-hover/card:opacity-50' />
+      <div className='absolute inset-0 z-10 rounded-2xl [mask-image:linear-gradient(white,transparent)] group-hover/card:opacity-50' />
       <motion.div
-        className={`absolute inset-0 rounded-2xl ${gradientClass} opacity-0  group-hover/card:opacity-100 backdrop-blur-xl transition duration-500`}
+        className={`absolute inset-0 rounded-2xl opacity-0 transition duration-500 group-hover/card:opacity-100 dark:hidden ${warmGradient}`}
         style={style}
       />
       <motion.div
-        className='absolute inset-0 rounded-2xl opacity-0 mix-blend-overlay  group-hover/card:opacity-100'
+        className={`absolute inset-0 hidden rounded-2xl opacity-0 transition duration-500 group-hover/card:opacity-100 dark:block ${coolGradient}`}
         style={style}
-      >
-        <div className='absolute inset-0 w-full h-full'>{stars}</div>
-      </motion.div>
+      />
     </div>
   );
 };

--- a/src/features/blog/ui/PostCard/PostCard.tsx
+++ b/src/features/blog/ui/PostCard/PostCard.tsx
@@ -55,7 +55,7 @@ export const PostCard = ({ post }: { post: PostResponse }) => {
         onMouseMove={handleMouseMove}
         className='group/card relative flex h-full w-full flex-col items-center justify-between overflow-hidden rounded-xl bg-transparent'
       >
-        <CardPattern mouseX={mouseX} mouseY={mouseY} />
+        <CardPattern mouseX={mouseX} mouseY={mouseY} seed={post.id ?? post.slug ?? post.title} />
         {post.category?.name && <span className={blogTheme.categoryPill}>{post.category.name}</span>}
         <h2
           className={`mb-1 line-clamp-2 text-center text-base font-semibold transition-colors group-hover/card:text-[#ffc8a0] dark:group-hover/card:text-[#3de8ff] ${blogTheme.textPrimary}`}

--- a/src/features/blog/ui/PostCard/PostCard.tsx
+++ b/src/features/blog/ui/PostCard/PostCard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { motion, useMotionValue, animate, AnimationPlaybackControlsWithThen } from 'framer-motion';
-import { CardPattern } from './CardPattern';
+import { type AnimationPlaybackControlsWithThen, animate, motion, useMotionValue } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 import type { PostResponse } from '@/entities/post/model/post';
 import { formatDateToYMD } from '@/shared/utils';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+import { CardPattern } from './CardPattern';
 
 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 export const generateRandomString = (length: number) => {
@@ -19,14 +20,16 @@ export const PostCard = ({ post }: { post: PostResponse }) => {
   const mouseX = useMotionValue(0);
   const mouseY = useMotionValue(0);
   const [_, setRandomString] = useState('');
-  const animationRef = useRef<{ x: AnimationPlaybackControlsWithThen; y: AnimationPlaybackControlsWithThen } | null>(null);
+  const animationRef = useRef<{ x: AnimationPlaybackControlsWithThen; y: AnimationPlaybackControlsWithThen } | null>(
+    null,
+  );
 
   useEffect(() => {
     const str = generateRandomString(1500);
     setRandomString(str);
   }, []);
 
-  function onMouseMove({ currentTarget, clientX, clientY }: React.MouseEvent<HTMLDivElement>) {
+  const handleMouseMove = ({ currentTarget, clientX, clientY }: React.MouseEvent<HTMLDivElement>) => {
     const { left, top } = currentTarget.getBoundingClientRect();
     const targetX = clientX - left;
     const targetY = clientY - top;
@@ -38,28 +41,29 @@ export const PostCard = ({ post }: { post: PostResponse }) => {
       x: animate(mouseX, targetX, { type: 'spring', stiffness: 200, damping: 30 }),
       y: animate(mouseY, targetY, { type: 'spring', stiffness: 200, damping: 30 }),
     };
-    const str = generateRandomString(1500);
-    setRandomString(str);
-  }
+    setRandomString(generateRandomString(1500));
+  };
 
   return (
     <motion.div
-      key={`${post.id}-card`}
-      whileHover={{ scale: 1.04, boxShadow: '0 0 16px #7dd3fc, 0 0 32px #7dd3fc55' }}
-      className='relative aspect-square bg-transparent rounded-xl border border-blue-300 shadow-[0_0_12px_#7dd3fc55] p-4 overflow-hidden transition'
+      whileHover={{ scale: 1.02, y: -2 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+      className={`relative aspect-square overflow-hidden rounded-xl p-4 transition ${blogTheme.card} ${blogTheme.cardHover}`}
     >
+      <span className={blogTheme.cardTopGlow} aria-hidden />
       <div
-        key={`${post.id}-card`}
-        onMouseMove={onMouseMove}
-        className='group/card rounded-3xl w-full relative flex flex-col items-center justify-between overflow-hidden bg-transparent h-full'
+        onMouseMove={handleMouseMove}
+        className='group/card relative flex h-full w-full flex-col items-center justify-between overflow-hidden rounded-xl bg-transparent'
       >
         <CardPattern mouseX={mouseX} mouseY={mouseY} />
-        {/* {post.thumbnail && (
-          <img src={post.thumbnail} alt={post.title} className='w-full h-1/2 object-cover rounded-md mb-2' />
-        )} */}
-        <span className='text-xs font-bold text-blue-200 mb-1'>{post.category?.name}</span>
-        <h2 className='text-base font-extrabold text-blue-100 text-center line-clamp-2 mb-1'>{post.title}</h2>
-        <span className='text-xs text-blue-300 mt-auto'>{formatDateToYMD(post.createdAt ?? '')}</span>
+        {post.category?.name && <span className={blogTheme.categoryPill}>{post.category.name}</span>}
+        <h2
+          className={`mb-1 line-clamp-2 text-center text-base font-semibold transition-colors group-hover/card:text-[#ffc8a0] dark:group-hover/card:text-[#3de8ff] ${blogTheme.textPrimary}`}
+          style={{ fontFamily: 'var(--font-syne), sans-serif' }}
+        >
+          {post.title}
+        </h2>
+        <span className={`mt-auto text-xs ${blogTheme.textMuted}`}>{formatDateToYMD(post.createdAt ?? '')}</span>
       </div>
     </motion.div>
   );

--- a/src/features/blog/ui/PostListCard/PostListCard.tsx
+++ b/src/features/blog/ui/PostListCard/PostListCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { PostResponse } from '@/entities/post/model/post';
-import { Tag } from '@/shared/ui';
 import { formatDateToYMD } from '@/shared/utils';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { motion } from 'framer-motion';
 import { Eye, LoaderCircle } from 'lucide-react';
 import Link from 'next/link';
@@ -19,6 +19,7 @@ export const PostListCard = ({ post, categoryName, categorySlug }: PostListCardP
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const href = `/blog/category/${categorySlug ?? post.category?.slug}/post/${post?.slug}`;
+  const categoryLabel = categoryName ?? post.category?.name;
 
   const handleNavigate = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
@@ -38,44 +39,40 @@ export const PostListCard = ({ post, categoryName, categorySlug }: PostListCardP
       onClick={handleNavigate}
       onMouseEnter={() => router.prefetch(href)}
       aria-busy={isPending}
-      className={`block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 transition-opacity ${
+      className={`block rounded-lg transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff9a3c]/50 dark:focus-visible:ring-[#3de8ff]/50 ${
         isPending ? 'pointer-events-none opacity-60' : ''
       }`}
     >
       <motion.div
         key={`${post.id}-list`}
-        whileHover={
-          isPending
-            ? undefined
-            : {
-                scale: 1.015,
-                boxShadow: '0 0 16px #7dd3fc, 0 0 32px #7dd3fc55',
-                backgroundColor: '#232946cc',
-              }
-        }
-        transition={{ type: 'spring', stiffness: 200, damping: 20 }}
-        className='rounded-lg px-4 py-3 transition cursor-pointer relative'
+        whileHover={isPending ? undefined : { x: 4 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className={`relative cursor-pointer rounded-xl px-4 py-3 transition ${blogTheme.listRow}`}
       >
+        <span className={blogTheme.listAccent} aria-hidden />
         {isPending && (
-          <span className='absolute right-4 top-4 text-cyan-300' aria-hidden>
+          <span className={`absolute right-4 top-4 ${blogTheme.textAccent}`} aria-hidden>
             <LoaderCircle className='size-4 animate-spin' />
           </span>
         )}
         <div className='flex items-center justify-between'>
-          <Tag color='neon' spacing='tight'>
-            #{categoryName ?? post.category?.name}
-          </Tag>
-          <span className='flex items-center justify-center gap-1 text-blue-300 text-xs'>
+          {categoryLabel && <span className={blogTheme.categoryPill}>#{categoryLabel}</span>}
+          <span className={`ml-auto flex items-center justify-center gap-1 text-xs ${blogTheme.textMuted}`}>
             <Eye size={15} className='inline-block' />
             {post?.views ?? 0}
           </span>
         </div>
-        <h2 className='text-lg font-extrabold text-blue-100 mt-1'>{post?.title}</h2>
-        <div className='flex items-center justify-between mt-2 text-xs text-blue-200'>
+        <h2
+          className={`mt-2 text-lg font-semibold transition-colors group-hover:text-[#ffc8a0] dark:group-hover:text-[#3de8ff] ${blogTheme.textPrimary}`}
+          style={{ fontFamily: 'var(--font-syne), sans-serif' }}
+        >
+          {post?.title}
+        </h2>
+        <div className={`mt-2 flex items-center justify-between text-xs ${blogTheme.textMuted}`}>
           <span>{post?.author ? post?.author?.name : '관리자'}</span>
           <span>{formatDateToYMD(post?.updatedAt ?? '')}</span>
         </div>
-        <hr className='my-6 border-blue-900/40' />
+        <hr className={`my-5 ${blogTheme.divider}`} />
       </motion.div>
     </Link>
   );

--- a/src/features/blog/ui/VisitorCounter.tsx
+++ b/src/features/blog/ui/VisitorCounter.tsx
@@ -50,7 +50,42 @@ export const VisitorCounter = () => {
   }, [data?.total, animate, counterRef]);
 
   if (isLoading) {
-    return <div className={`mb-4 text-sm ${blogTheme.textMuted}`}>Loading...</div>;
+    return (
+      <div className='relative mb-4 w-full' aria-busy='true'>
+        <div className={`relative flex flex-col items-center rounded-xl px-3 py-2.5 ${blogTheme.card}`}>
+          <span className={blogTheme.cardTopGlow} aria-hidden />
+          <div className='flex flex-row items-end gap-5'>
+            <div className='flex flex-col items-center'>
+              <div className='mb-1.5 h-2.5 w-8 animate-pulse rounded bg-[#ff9a3c]/25 dark:bg-[#3de8ff]/25' />
+              <div className='flex space-x-0.5'>
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={`today-skel-${i}`}
+                    className='h-7 w-5 animate-pulse rounded-md border border-[#ff9a3c]/20 bg-[#ff9a3c]/15 dark:border-[#3de8ff]/20 dark:bg-[#3de8ff]/15'
+                  />
+                ))}
+              </div>
+            </div>
+            <div className='mb-3 h-8 w-px bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/15' aria-hidden />
+            <div className='flex flex-col items-center'>
+              <div className='mb-1.5 h-2.5 w-8 animate-pulse rounded bg-[#e878a0]/25 dark:bg-[#7ec8ff]/25' />
+              <div className='flex space-x-0.5'>
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={`total-skel-${i}`}
+                    className='h-7 w-5 animate-pulse rounded-md border border-[#e878a0]/20 bg-[#c878ff]/15 dark:border-[#7ec8ff]/20 dark:bg-[#6366f1]/15'
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+          <div
+            className='mt-1.5 h-1.5 w-1.5 animate-pulse rounded-full bg-[#ff9a3c]/40 dark:bg-[#3de8ff]/40'
+            aria-hidden
+          />
+        </div>
+      </div>
+    );
   }
 
   const todayDigits = formatNumber(data?.today).split('');
@@ -75,7 +110,7 @@ export const VisitorCounter = () => {
             </span>
             <div className='flex space-x-0.5'>
               {todayDigits.map((digit, idx) => (
-                <Digit key={`today-${idx}-${digit}`} digit={digit} index={idx} variant='today' />
+                <Digit key={`today-${digit}-${idx}`} digit={digit} index={idx} variant='today' />
               ))}
             </div>
           </div>

--- a/src/features/blog/ui/VisitorCounter.tsx
+++ b/src/features/blog/ui/VisitorCounter.tsx
@@ -75,7 +75,7 @@ export const VisitorCounter = () => {
             </span>
             <div className='flex space-x-0.5'>
               {todayDigits.map((digit, idx) => (
-                <Digit key={`today-${digit}`} digit={digit} index={idx} variant='today' />
+                <Digit key={`today-${idx}-${digit}`} digit={digit} index={idx} variant='today' />
               ))}
             </div>
           </div>
@@ -88,7 +88,7 @@ export const VisitorCounter = () => {
             </span>
             <div className='flex space-x-0.5'>
               {totalDigits.map((digit, idx) => (
-                <Digit key={`total-${digit}`} digit={digit} index={idx} variant='total' />
+                <Digit key={`total-${idx}-${digit}`} digit={digit} index={idx} variant='total' />
               ))}
             </div>
           </div>

--- a/src/features/blog/ui/VisitorCounter.tsx
+++ b/src/features/blog/ui/VisitorCounter.tsx
@@ -1,8 +1,41 @@
 'use client';
 
-import { useRef, useEffect } from 'react';
 import { motion, useAnimate } from 'framer-motion';
+import { useEffect, useRef } from 'react';
 import { useVisitor } from '@/features/visitor/model';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
+const formatNumber = (num: number | undefined) => {
+  if (num == null) {
+    return '000';
+  }
+  return num.toString().padStart(3, '0');
+};
+
+type DigitProps = {
+  digit: string;
+  index: number;
+  variant: 'today' | 'total';
+};
+
+const Digit = ({ digit, index, variant }: DigitProps) => {
+  const todayClass =
+    'border-[#ff9a3c]/35 bg-gradient-to-b from-[#ffc8a0] via-[#ff9a3c] to-[#8a4a68] text-[#1c0e38] shadow-[0_0_10px_rgba(255,154,60,0.25)] dark:border-[#3de8ff]/35 dark:from-[#7ec8ff] dark:via-[#3de8ff] dark:to-[#1a4a6a] dark:text-[#070414] dark:shadow-[0_0_10px_rgba(61,232,255,0.2)]';
+  const totalClass =
+    'border-[#e878a0]/30 bg-gradient-to-b from-[#ffb870] via-[#c878ff] to-[#5a2868] text-[#1c0e38] shadow-[0_0_10px_rgba(200,120,180,0.2)] dark:border-[#7ec8ff]/25 dark:from-[#7ec8ff] dark:via-[#6366f1] dark:to-[#1e1b4b] dark:text-[#070414] dark:shadow-[0_0_10px_rgba(99,102,241,0.2)]';
+
+  return (
+    <motion.div
+      key={`${variant}-${index}-${digit}`}
+      className={`flex h-7 w-5 items-center justify-center rounded-md border text-base font-extrabold ${variant === 'today' ? todayClass : totalClass}`}
+      initial={{ rotateX: -90 }}
+      animate={{ rotateX: 0 }}
+      transition={{ type: 'spring', stiffness: 300 }}
+    >
+      {digit}
+    </motion.div>
+  );
+};
 
 export const VisitorCounter = () => {
   const [counterRef, animate] = useAnimate();
@@ -11,87 +44,63 @@ export const VisitorCounter = () => {
 
   useEffect(() => {
     if (prevCountRef.current !== data?.total && data?.total != null) {
-      // 숫자가 변경될 때만 애니메이션 적용
       animate(counterRef.current, { scale: [1, 1.2, 1] }, { duration: 0.5 });
       prevCountRef.current = data?.total;
     }
   }, [data?.total, animate, counterRef]);
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <div className={`mb-4 text-sm ${blogTheme.textMuted}`}>Loading...</div>;
   }
 
-  // 최소 3자리수로 포맷팅
-  const formatNumber = (num: number | undefined) => {
-    if (num == null) {
-      return '000';
-    }
-    return num.toString().padStart(3, '0');
-  };
-
-  // 각 자리수 분리
   const todayDigits = formatNumber(data?.today).split('');
   const totalDigits = formatNumber(data?.total).split('');
 
   return (
-    <div className='relative w-full'>
-      <div className='absolute inset-0 bg-gradient-to-r from-blue-900/40 to-fuchsia-900/30 rounded-xl rotate-2 scale-105 blur-md' />
+    <div className='relative mb-4 w-full'>
+      <div className='absolute inset-0 scale-105 rotate-1 rounded-xl bg-gradient-to-r from-[#ff9a3c]/15 to-[#8a4a68]/10 blur-md dark:from-[#3de8ff]/8 dark:to-[#6366f1]/10' />
       <motion.div
         ref={counterRef}
-        className='bg-[#181c2a]/80 px-3 py-2 rounded-xl border border-blue-400/40 backdrop-blur-md relative shadow-[0_0_12px_2px_#7dd3fc33] flex flex-col items-center'
-        whileHover={{
-          rotateY: 10,
-          rotateX: 3,
-          scale: 1.01,
-        }}
+        className={`relative flex flex-col items-center rounded-xl px-3 py-2.5 ${blogTheme.card}`}
+        whileHover={{ rotateY: 8, rotateX: 2, scale: 1.01 }}
         transition={{ type: 'spring', stiffness: 200 }}
+        aria-label='방문자 통계'
       >
-        <div className='flex flex-row items-end gap-4'>
-          {/* 오늘 방문자 */}
+        <span className={blogTheme.cardTopGlow} aria-hidden />
+
+        <div className='flex flex-row items-end gap-5'>
           <div className='flex flex-col items-center'>
-            <span className='text-[10px] text-blue-200 font-semibold mb-1 tracking-tight'>오늘</span>
+            <span className={`mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${blogTheme.textAccent}`}>
+              오늘
+            </span>
             <div className='flex space-x-0.5'>
               {todayDigits.map((digit, idx) => (
-                <motion.div
-                  key={`today-${idx}-${digit}`}
-                  className='w-5 h-7 bg-gradient-to-b from-blue-600 via-blue-400 to-blue-800 rounded-md flex items-center justify-center text-base font-extrabold text-white/90 border border-blue-300/40 shadow-[0_0_8px_#7dd3fc55]'
-                  initial={{ rotateX: -90 }}
-                  animate={{ rotateX: 0 }}
-                  transition={{ type: 'spring', stiffness: 300 }}
-                >
-                  {digit}
-                </motion.div>
+                <Digit key={`today-${digit}`} digit={digit} index={idx} variant='today' />
               ))}
             </div>
           </div>
-          {/* 총 방문자 */}
+
+          <div className='mb-3 h-8 w-px bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/15' aria-hidden />
+
           <div className='flex flex-col items-center'>
-            <span className='text-[10px] text-fuchsia-200 font-semibold mb-1 tracking-tight'>전체</span>
+            <span className={`mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${blogTheme.labelAccent}`}>
+              전체
+            </span>
             <div className='flex space-x-0.5'>
               {totalDigits.map((digit, idx) => (
-                <motion.div
-                  key={`total-${idx}-${digit}`}
-                  className='w-5 h-7 bg-gradient-to-b from-fuchsia-500 via-blue-400 to-blue-800 rounded-md flex items-center justify-center text-base font-extrabold text-white/90 border border-fuchsia-400/40 shadow-[0_0_8px_#f472b655]'
-                  initial={{ rotateX: -90 }}
-                  animate={{ rotateX: 0 }}
-                  transition={{ type: 'spring', stiffness: 300 }}
-                >
-                  {digit}
-                </motion.div>
+                <Digit key={`total-${digit}`} digit={digit} index={idx} variant='total' />
               ))}
             </div>
           </div>
         </div>
-        {/* LED 효과 */}
-        <div className='flex justify-center mt-1 space-x-0.5'>
+
+        <div className='mt-1.5 flex justify-center'>
           <motion.div
             key={`led-${data?.total}`}
-            className='w-1.5 h-1.5 bg-blue-400 rounded-full shadow-[0_0_4px_1px_#7dd3fc99]'
+            className='h-1.5 w-1.5 rounded-full bg-[#ff9a3c] shadow-[0_0_5px_1px_rgba(255,154,60,0.7)] dark:bg-[#3de8ff] dark:shadow-[0_0_5px_1px_rgba(61,232,255,0.6)]'
             animate={{ opacity: [1, 0.3, 1] }}
-            transition={{
-              duration: 1.5,
-              repeat: Number.POSITIVE_INFINITY,
-            }}
+            transition={{ duration: 1.5, repeat: Number.POSITIVE_INFINITY }}
+            aria-hidden
           />
         </div>
       </motion.div>

--- a/src/features/comment/ui/Comment.tsx
+++ b/src/features/comment/ui/Comment.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { LikeDislikeButtons } from '@/features/like/ui';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { Reply } from './Reply';
 import { ReplyForm } from './ReplyForm';
 import { CommentEditForm } from './CommentEditForm';
@@ -18,7 +19,6 @@ type CommentProps = {
 
 export function Comment({ comment, replies = [], postId }: CommentProps) {
   const { data: session } = useSession();
-
   const { deleteComment } = useDeleteComment();
   const [isEditing, setIsEditing] = useState(false);
 
@@ -36,53 +36,49 @@ export function Comment({ comment, replies = [], postId }: CommentProps) {
 
   return (
     <li>
-      <article className='bg-gradient-to-br from-slate-800/60 to-slate-700/40 backdrop-blur-sm border border-slate-600/50 md:from-[#181c2a]/80 md:to-[#232946]/60 md:border-blue-400/20 rounded-xl p-4 md:shadow-[0_0_8px_#7dd3fc22] relative'>
-        <header className='flex items-center gap-2 mb-1'>
-          <address className='not-italic font-bold text-blue-200'>{comment.author?.name}</address>
-          <time className='text-xs text-blue-300' dateTime={comment.createdAt}>
+      <article className={blogTheme.commentCard}>
+        <header className='mb-1 flex items-center gap-2'>
+          <address className={`not-italic font-bold ${blogTheme.textAccent}`}>{comment.author?.name}</address>
+          <time className={`text-xs ${blogTheme.textMuted}`} dateTime={comment.createdAt}>
             {formatDateToYMD(comment.createdAt ?? '')}
           </time>
         </header>
 
-        {/* 댓글 내용 또는 수정 폼 */}
         {isEditing ? (
           <CommentEditForm comment={comment} onCancel={() => setIsEditing(false)} />
         ) : (
-          <p className='text-slate-100 mb-2'>{comment.content}</p>
+          <p className={`mb-2 ${blogTheme.textPrimary}`}>{comment.content}</p>
         )}
 
-        {/* 액션 버튼들 */}
         {!isEditing && (
-          <div className='flex gap-2 items-center justify-between mt-2'>
-            <div className='flex gap-2 items-center'>
+          <div className='mt-2 flex items-center justify-between gap-2'>
+            <div className='flex items-center gap-2'>
               <button
                 type='button'
                 aria-label='답글 입력창 열기'
                 aria-expanded='false'
                 aria-controls={`reply-${comment.id}`}
-                className='text-xs text-blue-400 hover:text-blue-300 hover:underline flex items-center gap-1'
+                className={`flex items-center gap-1 ${blogTheme.commentLink}`}
               >
                 <span>답글</span>
                 <span aria-hidden>▼</span>
               </button>
               {canManage && (
                 <button
-                  className='text-xs text-cyan-400 hover:text-cyan-300 hover:underline'
+                  className={blogTheme.commentLink}
                   type='button'
                   aria-label='댓글 수정'
                   onClick={() => setIsEditing(true)}
-                  disabled={!canManage}
                 >
                   수정
                 </button>
               )}
               {canManage && (
                 <button
-                  className='text-xs text-fuchsia-400 hover:text-fuchsia-300 hover:underline'
+                  className='text-xs text-rose-400 hover:text-rose-300 hover:underline'
                   type='button'
                   aria-label='댓글 삭제'
                   onClick={() => handleDelete(comment.id ?? 0)}
-                  disabled={!canManage}
                 >
                   삭제
                 </button>
@@ -94,8 +90,7 @@ export function Comment({ comment, replies = [], postId }: CommentProps) {
           </div>
         )}
 
-        {/* 대댓글 영역 */}
-        <ul className='mt-4 space-y-3 pl-4 border-l-2 border-slate-600/60 md:border-blue-900/40'>
+        <ul className={`mt-4 space-y-3 ${blogTheme.commentReplyBorder}`}>
           {replies.length > 0 && replies.map((reply) => <Reply key={reply.id} reply={reply} />)}
           <ReplyForm commentId={comment.id} postId={postId} />
         </ul>

--- a/src/features/comment/ui/CommentEditForm.tsx
+++ b/src/features/comment/ui/CommentEditForm.tsx
@@ -4,6 +4,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button, useToast } from '@/shared/ui';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { useUpdateComment } from '../model';
 import type { Comment } from '@/entities/comment/model/types';
 
@@ -58,7 +59,7 @@ export function CommentEditForm({ comment, onCancel }: CommentEditFormProps) {
         render={({ field }) => (
           <textarea
             {...field}
-            className='w-full bg-[#232946] border border-blue-400/40 rounded-lg p-3 text-slate-100 font-mono resize-none focus:outline-none focus:ring-2 focus:ring-blue-400/60'
+            className={blogTheme.commentInput}
             rows={3}
             placeholder='댓글을 수정하세요...'
             disabled={isUpdating}
@@ -76,7 +77,7 @@ export function CommentEditForm({ comment, onCancel }: CommentEditFormProps) {
           variant='primary'
           onClick={onCancel}
           disabled={isUpdating}
-          className='border-blue-400/30 text-blue-300 hover:text-blue-200 hover:border-blue-400/50 hover:bg-blue-900/20 bg-none'
+          className={`border-[#ff9a3c]/30 bg-transparent text-[#ffb870] hover:border-[#ff9a3c]/50 hover:bg-[#ff9a3c]/10 hover:text-[#ffc8a0] dark:border-[#3de8ff]/30 dark:text-[#3de8ff] dark:hover:border-[#3de8ff]/50 dark:hover:bg-[#3de8ff]/10 dark:hover:text-[#7ec8ff]`}
         >
           취소
         </Button>

--- a/src/features/comment/ui/CommentForm.tsx
+++ b/src/features/comment/ui/CommentForm.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useCreateComment, commentFormSchema, type CommentFormSchema } from '../model';
 import { Button, useToast } from '@/shared/ui';
 import { useSession } from 'next-auth/react';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 type CommentFormProps = {
   postId: number;
@@ -59,7 +60,7 @@ export function CommentForm({ postId, disabled = false }: CommentFormProps) {
           <textarea
             id='comment-input'
             {...register('content')}
-            className='w-full bg-[#232946] border border-blue-400/40 rounded-lg p-3 pr-16 text-slate-100 font-mono resize-none focus:outline-none focus:ring-2 focus:ring-blue-400/60 md:shadow-[0_0_8px_#7dd3fc33]'
+            className={`${blogTheme.commentInput} pr-16`}
             rows={3}
             placeholder={isAuthenticated ? '댓글을 입력하세요...' : '로그인이 필요합니다'}
             aria-label='댓글 입력'
@@ -76,8 +77,8 @@ export function CommentForm({ postId, disabled = false }: CommentFormProps) {
       </div>
       {errors.content && <p className='text-red-400 text-xs mt-1 mb-2'>{errors.content.message}</p>}
       {!isAuthenticated && (
-        <p className='text-blue-300 text-xs mt-1 mb-2 text-center'>
-          댓글을 작성하려면 <span className='text-blue-200 font-medium'>로그인</span>이 필요합니다
+        <p className={`mt-1 mb-2 text-center text-xs ${blogTheme.textMuted}`}>
+          댓글을 작성하려면 <span className={`font-medium ${blogTheme.textAccent}`}>로그인</span>이 필요합니다
         </p>
       )}
     </form>

--- a/src/features/comment/ui/CommentSection.tsx
+++ b/src/features/comment/ui/CommentSection.tsx
@@ -1,6 +1,7 @@
 import { CommentForm } from './CommentForm';
 import { Comment } from './Comment';
 import { getComments } from '../api';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,17 +13,13 @@ export async function CommentSection({ postId }: CommentSectionProps) {
   const comments = await getComments({ postId });
 
   return (
-    <section className='mt-10 relative md:bg-gradient-to-br md:backdrop-blur-sm md:border md:from-[#181c2a]/90 md:via-[#232946]/90 md:to-[#232946]/80 md:border-blue-400/30 rounded-2xl md:shadow-[0_0_24px_4px_#7dd3fc22] px-4 sm:px-6 md:px-8 py-8 max-w-4xl mx-4 md:overflow-hidden lg:mx-auto'>
-      <div className='absolute inset-0 pointer-events-none z-0 hidden md:block'>
-        <div className='w-full h-full bg-gradient-to-tr from-blue-900/20 via-fuchsia-900/10 to-blue-800/10 blur-[2px]' />
+    <section className={blogTheme.commentSection}>
+      <div className='pointer-events-none absolute inset-0 z-0 hidden md:block'>
+        <div className='h-full w-full bg-gradient-to-tr from-[#8a4a68]/12 via-[#1c0e38]/15 to-[#ffc090]/8 blur-[2px] dark:from-cyan-900/15 dark:via-fuchsia-900/8 dark:to-cyan-800/8' />
       </div>
       <div className='relative z-10'>
-        <h2 className='text-lg font-bold text-blue-200 mb-4'>댓글</h2>
-
-        {/* 댓글 입력 영역 */}
+        <h2 className={`mb-4 text-lg font-bold ${blogTheme.textPrimary}`}>댓글</h2>
         <CommentForm postId={postId} />
-
-        {/* 댓글 목록 */}
         <ul className='space-y-6'>
           {comments.map((comment) => (
             <Comment comment={comment} key={comment?.id} replies={comment?.replies} postId={postId} />

--- a/src/features/comment/ui/Reply.tsx
+++ b/src/features/comment/ui/Reply.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { ReplyType } from '@/entities/comment/model/types';
 import { LikeDislikeButtons } from '@/features/like/ui';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { formatDateToYMD } from '@/shared/utils';
 import { useDeleteComment } from '../model';
 import { ReplyEditForm } from './ReplyEditForm';
@@ -34,10 +35,10 @@ export function Reply({ reply }: ReplyProps) {
 
   return (
     <li>
-      <article className='bg-gradient-to-br from-slate-700/50 to-slate-600/30 backdrop-blur-sm border border-slate-600/40 md:from-[#232946]/80 md:to-[#181c2a]/40 md:border-fuchsia-400/20 rounded-lg p-3 relative'>
-        <header className='flex items-center gap-2 mb-1'>
-          <address className='not-italic font-bold text-fuchsia-200'>{reply.author?.name}</address>
-          <time className='text-xs text-fuchsia-300' dateTime={reply.createdAt}>
+      <article className={blogTheme.commentReplyCard}>
+        <header className='mb-1 flex items-center gap-2'>
+          <address className={`not-italic font-bold ${blogTheme.textAccent}`}>{reply.author?.name}</address>
+          <time className={`text-xs ${blogTheme.textMuted}`} dateTime={reply.createdAt}>
             {formatDateToYMD(reply.createdAt ?? '')}
           </time>
         </header>
@@ -45,20 +46,15 @@ export function Reply({ reply }: ReplyProps) {
           <ReplyEditForm reply={reply} onCancel={handleCancelEdit} />
         ) : (
           <>
-            <p className='text-slate-100 mb-2'>{reply.content}</p>
-            <div className='flex gap-2 items-center justify-between mt-2'>
+            <p className={`mb-2 ${blogTheme.textPrimary}`}>{reply.content}</p>
+            <div className='mt-2 flex items-center justify-between gap-2'>
               {canManage && (
-                <div className='flex gap-2 items-center'>
-                  <button
-                    className='text-xs text-cyan-400 hover:text-cyan-300 hover:underline'
-                    type='button'
-                    aria-label='대댓글 수정'
-                    onClick={handleEdit}
-                  >
+                <div className='flex items-center gap-2'>
+                  <button className={blogTheme.commentLink} type='button' aria-label='대댓글 수정' onClick={handleEdit}>
                     수정
                   </button>
                   <button
-                    className='text-xs text-fuchsia-400 hover:text-fuchsia-300 hover:underline'
+                    className='text-xs text-rose-400 hover:text-rose-300 hover:underline'
                     type='button'
                     aria-label='대댓글 삭제'
                     onClick={handleDelete}

--- a/src/features/comment/ui/ReplyEditForm.tsx
+++ b/src/features/comment/ui/ReplyEditForm.tsx
@@ -4,6 +4,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button, useToast } from '@/shared/ui';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { useUpdateComment } from '../model';
 import type { ReplyType } from '@/entities/comment/model/types';
 
@@ -58,7 +59,7 @@ export function ReplyEditForm({ reply, onCancel }: ReplyEditFormProps) {
         render={({ field }) => (
           <textarea
             {...field}
-            className='w-full bg-[#232946] border border-fuchsia-400/40 rounded-lg p-3 text-slate-100 font-mono resize-none focus:outline-none focus:ring-2 focus:ring-fuchsia-400/60'
+            className={blogTheme.commentInput}
             rows={2}
             placeholder='대댓글을 수정하세요...'
             disabled={isUpdating}
@@ -76,7 +77,7 @@ export function ReplyEditForm({ reply, onCancel }: ReplyEditFormProps) {
           variant='primary'
           onClick={onCancel}
           disabled={isUpdating}
-          className='border-fuchsia-400/30 text-fuchsia-300 hover:text-fuchsia-200 hover:border-fuchsia-400/50 hover:bg-fuchsia-900/20 bg-none'
+          className={`border-[#ff9a3c]/30 bg-transparent text-[#ffb870] hover:border-[#ff9a3c]/50 hover:bg-[#ff9a3c]/10 hover:text-[#ffc8a0] dark:border-[#3de8ff]/30 dark:text-[#3de8ff] dark:hover:border-[#3de8ff]/50 dark:hover:bg-[#3de8ff]/10 dark:hover:text-[#7ec8ff]`}
         >
           취소
         </Button>

--- a/src/features/comment/ui/ReplyForm.tsx
+++ b/src/features/comment/ui/ReplyForm.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useSession } from 'next-auth/react';
 import { useCreateComment, replyFormSchema, type ReplyFormSchema } from '../model';
 import { Button, useToast } from '@/shared/ui';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 type ReplyFormProps = {
   commentId?: number;
@@ -60,7 +61,7 @@ export function ReplyForm({ commentId, postId }: ReplyFormProps) {
           <textarea
             id={`reply-input-${commentId}`}
             {...register('content')}
-            className='w-full bg-[#232946] border border-blue-400/40 rounded-lg p-2 pr-14 text-slate-100 font-mono resize-none focus:outline-none focus:ring-2 focus:ring-blue-400/60'
+            className={`${blogTheme.commentInput} p-2 pr-14`}
             rows={2}
             placeholder={!isAuthenticated ? '로그인이 필요합니다' : '대댓글을 입력하세요...'}
             aria-label='대댓글 입력'

--- a/src/features/tag/ui/Tag.tsx
+++ b/src/features/tag/ui/Tag.tsx
@@ -2,20 +2,15 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 
 const colorCombos = [
-  'bg-blue-500 border-blue-200',
-  'bg-pink-500 border-pink-200',
-  'bg-green-500 border-green-200',
-  'bg-yellow-500 border-yellow-200',
-  'bg-purple-500 border-purple-200',
-  'bg-cyan-500 border-cyan-200',
-  'bg-fuchsia-500 border-fuchsia-200',
   'bg-orange-500 border-orange-200',
-  'bg-sky-500 border-sky-200',
   'bg-rose-500 border-rose-200',
+  'bg-amber-500 border-amber-200',
+  'bg-fuchsia-500 border-fuchsia-200',
+  'bg-cyan-500 border-cyan-200 dark:bg-cyan-500 dark:border-cyan-200',
+  'bg-indigo-500 border-indigo-200 dark:bg-indigo-500 dark:border-indigo-200',
 ];
 
 export const Tag = ({ tag, count }: { tag: { id?: number; name?: string }; count: number }) => {
-  // 태그 이름을 해시로 변환해서 색상 인덱스 결정
   function hashString(str: string) {
     let hash = 0;
     for (let i = 0; i < str.length; i++) {
@@ -30,16 +25,16 @@ export const Tag = ({ tag, count }: { tag: { id?: number; name?: string }; count
   return (
     <motion.span
       key={tag.id}
-      whileHover={{ scale: 1.08, boxShadow: '0 0 8px #7dd3fc, 0 0 16px #7dd3fc55' }}
-      className='bg-blue-900/40 px-2 py-1 rounded-lg text-xs font-mono border border-blue-300 shadow-[0_0_8px_#7dd3fc55] transition relative'
+      whileHover={{ scale: 1.06 }}
+      className='relative rounded-lg border border-[#ff9a3c]/25 bg-[#ff9a3c]/8 px-2 py-1 text-xs font-mono shadow-[0_0_10px_rgba(255,154,60,0.1)] transition dark:border-[#3de8ff]/25 dark:bg-[#3de8ff]/8 dark:shadow-[0_0_10px_rgba(61,232,255,0.1)]'
     >
       <Link
         href={`/blog/${tag.name}`}
-        className='inline-block px-3 py-1 back drop-blur-sm text-blue-100 text-xs font-mono'
+        className='inline-block px-3 py-1 text-xs font-mono text-[#ffc8a0] backdrop-blur-sm dark:text-[#3de8ff]'
       >
         {tag.name}
         <motion.span
-          className={`absolute -top-1 -right-1 text-white text-xs w-4 h-4 flex items-center justify-center rounded-full border-2 ${colorClass}`}
+          className={`absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border-2 text-xs text-white ${colorClass}`}
           initial={{ scale: 0 }}
           whileInView={{ scale: 1 }}
           transition={{ delay: 0.2 }}

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -82,7 +82,16 @@ export const fetcher = async <P extends Path, M extends Method<P>>({
   });
 
   if (!res.ok) {
-    throw new Error();
+    let message = `Request failed: ${res.status} ${res.statusText}`;
+    try {
+      const errorBody = await res.json();
+      if (typeof errorBody?.error === 'string') {
+        message = errorBody.error;
+      }
+    } catch {
+      // ignore non-json error bodies
+    }
+    throw new Error(message);
   }
 
   return res.json();

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -85,10 +85,16 @@ export const fetcher = async <P extends Path, M extends Method<P>>({
     let message = `Request failed: ${res.status} ${res.statusText}`;
     try {
       const errorBody = await res.json();
-      if (typeof errorBody?.error === 'string') {
+      if (typeof errorBody?.error === 'string' && errorBody.error.trim() !== '') {
         message = errorBody.error;
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
       // ignore non-json error bodies
     }
     throw new Error(message);

--- a/src/shared/ui/NovelViewer.tsx
+++ b/src/shared/ui/NovelViewer.tsx
@@ -11,8 +11,15 @@ const extensions = [...defaultExtensions];
 
 export default function NovelViewer({ content }: NovelViewerProps) {
   const processedValue = content ? preprocessHTML(content) : content;
-  
+
   return (
-    <EditorContent extensions={extensions} immediatelyRender={false} editable={false} initialContent={processedValue as any} />
+    <div className='blog-prose'>
+      <EditorContent
+        extensions={extensions}
+        immediatelyRender={false}
+        editable={false}
+        initialContent={processedValue as any}
+      />
+    </div>
   );
 }

--- a/src/shared/ui/PostSummary.tsx
+++ b/src/shared/ui/PostSummary.tsx
@@ -2,6 +2,7 @@
 
 import { usePostSummary } from '@/features/post/model';
 import { isValidSummary } from '@/features/post/utils';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import NovelViewer from './NovelViewer';
 
 interface PostSummaryProps {
@@ -17,32 +18,30 @@ export function PostSummary({ post }: PostSummaryProps) {
 
   if (isLoading) {
     return (
-      <div className='relative bg-gradient-to-r from-blue-900/20 to-purple-900/20 border border-blue-400/30 rounded-lg p-4 mb-6'>
-        <div className='flex items-center gap-2 mb-2'>
-          <div className='w-4 h-4 bg-blue-400 rounded-full animate-pulse' />
-          <span className='text-blue-200 text-sm font-medium'>AI 요약 생성 중...</span>
+      <div className={`relative mb-6 ${blogTheme.summaryBox}`}>
+        <div className='mb-2 flex items-center gap-2'>
+          <div className='h-4 w-4 animate-pulse rounded-full bg-[#ff9a3c]/60 dark:bg-[#3de8ff]/60' />
+          <span className={`text-sm font-medium ${blogTheme.textAccent}`}>AI 요약 생성 중...</span>
         </div>
         <div className='space-y-2'>
-          <div className='h-3 bg-blue-800/30 rounded animate-pulse' />
-          <div className='h-3 bg-blue-800/30 rounded w-3/4 animate-pulse' />
+          <div className='h-3 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+          <div className='h-3 w-3/4 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
         </div>
       </div>
     );
   }
 
   if (error || !isValidSummary(summary)) {
-    return null; // 에러나 유효하지 않은 요약은 표시하지 않음
+    return null;
   }
 
   return (
-    <div className='relative bg-gradient-to-r from-blue-900/20 to-purple-900/20 border border-blue-400/30 rounded-lg p-4 mb-6'>
-      <div className='flex items-center gap-2 mb-3'>
-        <div className='w-4 h-4 bg-blue-400 rounded-full' />
-        <span className='text-blue-200 text-sm font-medium'>🤖 AI 요약</span>
+    <div className={`relative mb-6 ${blogTheme.summaryBox}`}>
+      <div className='mb-3 flex items-center gap-2'>
+        <div className='h-4 w-4 rounded-full bg-[#ff9a3c]/70 dark:bg-[#3de8ff]/70' />
+        <span className={`text-sm font-medium ${blogTheme.textAccent}`}>🤖 AI 요약</span>
       </div>
-      <div className='text-blue-100'>
-        <NovelViewer content={summary} />
-      </div>
+      <NovelViewer content={summary} />
     </div>
   );
-}
+};

--- a/src/shared/ui/ThemeToggleButton.tsx
+++ b/src/shared/ui/ThemeToggleButton.tsx
@@ -16,8 +16,8 @@ const variantClass: Record<ThemeToggleVariant, string> = {
   // 홈 Navbar Log In 버튼과 동일 톤
   navbar:
     'h-9 w-9 rounded-xl border border-[#858585] text-gray-300 hover:border-white hover:text-white hover:shadow-[0_0_10px_#ffffff]',
-  // 블로그 헤더 '이동' 버튼과 동일 톤
-  blog: 'h-9 w-9 rounded-full border border-blue-400/30 bg-gradient-to-r from-purple-500/20 to-blue-500/20 text-blue-100 hover:from-purple-400/30 hover:to-blue-400/30 hover:border-blue-300/50',
+  // 블로그 헤더 네비 버튼과 동일 톤
+  blog: 'h-9 w-9 rounded-lg border border-[#ff9a3c]/30 bg-[#2a1545]/60 text-[#ffc8a0] transition hover:border-[#ff9a3c]/55 hover:bg-[#3d1f5c]/70 hover:shadow-[0_0_12px_rgba(255,154,60,0.2)] dark:border-[#3de8ff]/25 dark:bg-black/35 dark:text-[#3de8ff] dark:hover:border-[#3de8ff]/50 dark:hover:bg-black/50 dark:hover:shadow-[0_0_12px_rgba(61,232,255,0.15)]',
   // 어드민 헤더용 최소 스타일
   admin:
     'h-9 w-9 rounded-lg border border-white/25 text-white/80 hover:border-white/50 hover:text-white hover:bg-white/10',

--- a/src/shared/ui/skeleton/PostCardSkeleton.tsx
+++ b/src/shared/ui/skeleton/PostCardSkeleton.tsx
@@ -1,27 +1,20 @@
-import { motion } from 'framer-motion';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 export const PostCardSkeleton = () => {
   return (
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className='relative group block p-2 h-full w-full'>
-      <div className='bg-[#232946]/40 rounded-3xl p-4 h-full border border-blue-400/20'>
-        {/* 제목 스켈레톤 */}
-        <div className='h-4 bg-blue-400/20 rounded mb-3 animate-pulse' />
-        <div className='h-3 bg-blue-400/20 rounded mb-2 w-3/4 animate-pulse' />
-
-        {/* 카테고리 스켈레톤 */}
-        <div className='h-3 bg-purple-400/20 rounded mb-3 w-1/3 animate-pulse' />
-
-        {/* 날짜 스켈레톤 */}
-        <div className='h-3 bg-blue-400/20 rounded mb-3 w-1/2 animate-pulse' />
-
-        {/* 요약 스켈레톤 */}
+    <div className='relative block h-full w-full p-2' aria-hidden>
+      <div className={`h-full rounded-3xl p-4 ${blogTheme.card}`}>
+        <span className={blogTheme.cardTopGlow} />
+        <div className='mb-3 h-4 animate-pulse rounded bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+        <div className='mb-2 h-3 w-3/4 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+        <div className='mb-3 h-3 w-1/3 animate-pulse rounded bg-[#e878a0]/20 dark:bg-[#7ec8ff]/20' />
+        <div className='mb-3 h-3 w-1/2 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
         <div className='space-y-2'>
-          <div className='h-3 bg-blue-400/20 rounded animate-pulse' />
-          <div className='h-3 bg-blue-400/20 rounded w-5/6 animate-pulse' />
-          <div className='h-3 bg-blue-400/20 rounded w-4/6 animate-pulse' />
+          <div className='h-3 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+          <div className='h-3 w-5/6 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+          <div className='h-3 w-4/6 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 };
-

--- a/src/shared/ui/skeleton/PostListCardSkeleton.tsx
+++ b/src/shared/ui/skeleton/PostListCardSkeleton.tsx
@@ -1,45 +1,36 @@
-import { motion } from 'framer-motion';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 export const PostListCardSkeleton = () => {
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      className='bg-[#232946]/40 rounded-2xl p-6 border border-blue-400/20 hover:border-blue-400/40 transition-colors'
-    >
-      <div className='flex flex-col lg:flex-row gap-6'>
-        {/* 왼쪽: 텍스트 영역 */}
+    <div className={`relative rounded-2xl p-6 ${blogTheme.card}`} aria-hidden>
+      <span className={blogTheme.cardTopGlow} />
+      <div className='flex flex-col gap-6 lg:flex-row'>
         <div className='flex-1 space-y-4'>
-          {/* 제목 스켈레톤 */}
-          <div className='h-6 bg-blue-400/20 rounded animate-pulse' />
-          <div className='h-5 bg-blue-400/20 rounded w-4/5 animate-pulse' />
+          <div className='h-6 animate-pulse rounded bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+          <div className='h-5 w-4/5 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
 
-          {/* 메타 정보 스켈레톤 */}
           <div className='flex items-center gap-4 text-sm'>
-            <div className='h-4 bg-purple-400/20 rounded w-16 animate-pulse' />
-            <div className='h-4 bg-blue-400/20 rounded w-24 animate-pulse' />
-            <div className='h-4 bg-green-400/20 rounded w-20 animate-pulse' />
+            <div className='h-4 w-16 animate-pulse rounded bg-[#e878a0]/20 dark:bg-[#7ec8ff]/20' />
+            <div className='h-4 w-24 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-4 w-20 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
           </div>
 
-          {/* 내용 스켈레톤 */}
           <div className='space-y-2'>
-            <div className='h-4 bg-blue-400/20 rounded animate-pulse' />
-            <div className='h-4 bg-blue-400/20 rounded w-5/6 animate-pulse' />
-            <div className='h-4 bg-blue-400/20 rounded w-4/6 animate-pulse' />
-            <div className='h-4 bg-blue-400/20 rounded w-3/4 animate-pulse' />
+            <div className='h-4 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-4 w-5/6 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-4 w-4/6 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+            <div className='h-4 w-3/4 animate-pulse rounded bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
           </div>
 
-          {/* 태그 스켈레톤 */}
           <div className='flex gap-2'>
-            <div className='h-6 bg-blue-400/20 rounded-full px-3 w-16 animate-pulse' />
-            <div className='h-6 bg-blue-400/20 rounded-full px-3 w-20 animate-pulse' />
-            <div className='h-6 bg-blue-400/20 rounded-full px-3 w-14 animate-pulse' />
+            <div className='h-6 w-16 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+            <div className='h-6 w-20 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
+            <div className='h-6 w-14 animate-pulse rounded-full bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/20' />
           </div>
         </div>
 
-        {/* 오른쪽: 이미지 영역 (데스크톱에서만 표시) */}
-        <div className='hidden lg:block w-48 h-32 bg-blue-400/20 rounded-xl animate-pulse' />
+        <div className='hidden h-32 w-48 animate-pulse rounded-xl bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15 lg:block' />
       </div>
-    </motion.div>
+    </div>
   );
 };

--- a/src/shared/ui/skeleton/SidebarSkeleton.tsx
+++ b/src/shared/ui/skeleton/SidebarSkeleton.tsx
@@ -1,51 +1,66 @@
-import { motion } from 'framer-motion';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 export const SidebarSkeleton = () => {
   return (
-    <motion.aside
-      initial={{ x: '100%', opacity: 0 }}
-      animate={{ x: 0, opacity: 1 }}
-      className='hidden lg:flex h-screen flex-shrink-0 flex-col gap-8 w-80 p-6 bg-[#181c2a]/80 border-l border-blue-300 shadow-[0_0_16px_4px_#7dd3fc55] backdrop-blur-sm z-10 relative'
+    <aside
+      className={`relative z-10 hidden h-screen w-80 flex-shrink-0 flex-col gap-8 p-6 lg:flex ${blogTheme.sidebar}`}
       style={{ minWidth: 320 }}
+      aria-busy='true'
+      aria-label='사이드바 불러오는 중'
     >
-      {/* Visitor Counter 스켈레톤 */}
-      <div className='space-y-3'>
-        <div className='h-6 bg-blue-400/20 rounded animate-pulse' />
-        <div className='h-4 bg-blue-400/20 rounded w-3/4 animate-pulse' />
-        <div className='h-8 bg-gradient-to-r from-blue-400/20 to-purple-400/20 rounded-lg animate-pulse' />
+      <div className={`relative rounded-xl px-3 py-2.5 ${blogTheme.card}`}>
+        <span className={blogTheme.cardTopGlow} aria-hidden />
+        <div className='flex flex-row items-end justify-center gap-5'>
+          <div className='flex flex-col items-center'>
+            <div className='mb-1.5 h-2.5 w-8 animate-pulse rounded bg-[#ff9a3c]/25 dark:bg-[#3de8ff]/25' />
+            <div className='flex space-x-0.5'>
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={`visitor-today-${i}`}
+                  className='h-7 w-5 animate-pulse rounded-md bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15'
+                />
+              ))}
+            </div>
+          </div>
+          <div className='mb-3 h-8 w-px bg-[#ff9a3c]/20 dark:bg-[#3de8ff]/15' aria-hidden />
+          <div className='flex flex-col items-center'>
+            <div className='mb-1.5 h-2.5 w-8 animate-pulse rounded bg-[#e878a0]/25 dark:bg-[#7ec8ff]/25' />
+            <div className='flex space-x-0.5'>
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={`visitor-total-${i}`}
+                  className='h-7 w-5 animate-pulse rounded-md bg-[#c878ff]/15 dark:bg-[#6366f1]/15'
+                />
+              ))}
+            </div>
+          </div>
+        </div>
       </div>
 
-      {/* Category 섹션 스켈레톤 */}
       <div>
-        <div className='px-3 py-2 flex items-center justify-between'>
-          <div className='h-6 bg-blue-400/20 rounded w-24 animate-pulse' />
-        </div>
-        <nav className='flex flex-col gap-2 px-3 py-4'>
-          {/* 전체 메뉴 스켈레톤 */}
-          <div className='h-8 bg-blue-400/20 rounded-lg animate-pulse' />
-
-          {/* 카테고리 메뉴 스켈레톤들 */}
-          {Array.from({ length: 6 }).map((_) => (
+        <div className='mb-3 h-4 w-24 animate-pulse rounded bg-[#ff9a3c]/25 dark:bg-[#3de8ff]/25' />
+        <nav className='flex flex-col gap-2'>
+          <div className='h-8 animate-pulse rounded-lg bg-[#ff9a3c]/15 dark:bg-[#3de8ff]/15' />
+          {[0, 1, 2, 3, 4, 5].map((i) => (
             <div
-              key={`sidebar-category-skeleton-${Math.random()}`}
-              className='h-8 bg-blue-400/20 rounded-lg animate-pulse'
+              key={`sidebar-category-${i}`}
+              className='h-8 animate-pulse rounded-lg bg-[#ff9a3c]/12 dark:bg-[#3de8ff]/12'
             />
           ))}
         </nav>
       </div>
 
-      {/* Tags 섹션 스켈레톤 */}
       <div>
-        <div className='h-5 bg-blue-400/20 rounded w-16 mb-2 animate-pulse' />
+        <div className='mb-2 h-4 w-16 animate-pulse rounded bg-[#ff9a3c]/25 dark:bg-[#3de8ff]/25' />
         <div className='flex flex-wrap gap-2'>
-          {Array.from({ length: 8 }).map((_) => (
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
             <div
-              key={`sidebar-tag-skeleton-${Math.random()}`}
-              className='h-6 bg-purple-400/20 rounded-full px-3 w-16 animate-pulse'
+              key={`sidebar-tag-${i}`}
+              className='h-6 w-16 animate-pulse rounded-full bg-[#e878a0]/15 dark:bg-[#7ec8ff]/15'
             />
           ))}
         </div>
       </div>
-    </motion.aside>
+    </aside>
   );
 };

--- a/src/widgets/post/ui/BlogHeader.tsx
+++ b/src/widgets/post/ui/BlogHeader.tsx
@@ -42,6 +42,8 @@ export default function BlogHeader() {
         <div className='flex items-center'>
           <button
             type='button'
+            onClick={() => handleNavigation('/blog')}
+            aria-label='블로그 홈으로 이동'
             className='m-0 flex cursor-pointer select-none items-center gap-2 border-none bg-transparent p-0 text-base font-semibold tracking-wide focus:outline-none'
             style={syne}
           >
@@ -177,6 +179,8 @@ export default function BlogHeader() {
           <div className='relative flex h-10 items-center justify-center px-12'>
             <button
               type='button'
+              onClick={() => handleNavigation('/blog')}
+              aria-label='블로그 홈으로 이동'
               className='flex items-center gap-2 border-none bg-transparent p-0 text-base font-semibold'
               style={syne}
             >

--- a/src/widgets/post/ui/BlogHeader.tsx
+++ b/src/widgets/post/ui/BlogHeader.tsx
@@ -8,8 +8,11 @@ import { signOut, useSession } from 'next-auth/react';
 import { useState } from 'react';
 import { Dropdown } from '@/shared/ui';
 import ThemeToggleButton from '@/shared/ui/ThemeToggleButton';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { BlogSearch } from './BlogSearch';
 import { MobileNavbar } from './MobileNavbar';
+
+const syne = { fontFamily: 'var(--font-syne), sans-serif' } as const;
 
 export default function BlogHeader() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -25,209 +28,178 @@ export default function BlogHeader() {
     await signOut({ callbackUrl: '/' });
   };
 
+  const navBtnClass = `flex items-center gap-2 rounded-lg px-3 py-2 transition ${blogTheme.navBtn}`;
+
   return (
     <>
-      {/* 데스크톱 헤더 */}
       <motion.div
-        className='hidden lg:flex items-center justify-between mb-8 p-4 rounded-full bg-black/20 backdrop-blur-md border border-blue-400/20 shadow-2xl h-16 max-w-4xl mx-auto w-full'
-        initial={{ y: -20, opacity: 0 }}
+        className={`relative mx-auto mb-8 hidden h-16 w-full max-w-4xl items-center justify-between rounded-xl p-4 lg:flex ${blogTheme.chromeBar}`}
+        initial={{ y: -16, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.5 }}
-        style={{
-          boxShadow: `
-            0 8px 32px rgba(0, 0, 0, 0.3),
-            0 0 20px rgba(59, 130, 246, 0.2)
-          `,
-        }}
+        transition={{ duration: 0.4 }}
       >
-        {/* 좌측: 로고 */}
+        <span className={blogTheme.chromeShine} aria-hidden />
         <div className='flex items-center'>
-          <motion.button
+          <button
             type='button'
-            whileHover={{ scale: 1.02 }}
-            className='font-extrabold text-lg text-blue-100 flex items-center gap-2 cursor-pointer select-none hover:text-white bg-transparent border-none p-0 m-0 focus:outline-none transition-colors duration-300'
+            className='m-0 flex cursor-pointer select-none items-center gap-2 border-none bg-transparent p-0 text-base font-semibold tracking-wide focus:outline-none'
+            style={syne}
           >
-            <Image src='/logo.png' alt='logo' width={24} height={24} /> 3D Tech Blog
-          </motion.button>
+            <Image src='/logo.png' alt='logo' width={22} height={22} />
+            <span className={blogTheme.titleGradient}>3D Tech Blog</span>
+          </button>
         </div>
 
-        {/* 우측: 네비게이션 + 검색 */}
         <div className='flex items-center gap-3'>
           <ThemeToggleButton variant='blog' />
-          {/* 네비게이션 드롭다운 */}
           <Dropdown
             className='relative z-50'
             placement='bottom-right'
-            contentClassName='min-w-[120px]'
+            contentClassName={`min-w-[120px] ${blogTheme.dropdown}`}
             trigger={({ ref, onClick }) => (
               <motion.button
                 ref={ref as React.RefObject<HTMLButtonElement>}
                 type='button'
                 onClick={onClick}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className='flex items-center gap-2 px-3 py-2 rounded-full bg-gradient-to-r from-purple-500/20 to-blue-500/20 border border-blue-400/30 text-blue-100 hover:from-purple-400/30 hover:to-blue-400/30 hover:border-blue-300/50 transition-all duration-300 group'
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.97 }}
+                className={navBtnClass}
+                style={syne}
                 title='페이지 이동'
               >
-                <Navigation size={16} className='group-hover:rotate-12 transition-transform duration-300' />
-                <span className='text-sm font-mono font-medium'>이동</span>
+                <Navigation size={15} className={blogTheme.textAccent} />
+                <span className='text-[11px] font-medium uppercase tracking-[0.14em]'>Go</span>
               </motion.button>
             )}
           >
-            <motion.button
+            <button
               type='button'
               onClick={() => handleNavigation('/')}
-              whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-              className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+              className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm ${blogTheme.dropdownItem}`}
             >
               <Globe size={14} />
-              <span className='text-sm'>메인으로</span>
-            </motion.button>
-            <motion.button
+              Home
+            </button>
+            <button
               type='button'
               onClick={() => handleNavigation('/blog')}
-              whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-              className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+              className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm ${blogTheme.dropdownItem}`}
             >
               <Home size={14} />
-              <span className='text-sm'>블로그로</span>
-            </motion.button>
+              Blog
+            </button>
             {isAuthenticated ? (
-              <motion.button
+              <button
                 type='button'
                 onClick={handleLogout}
-                whileHover={{ scale: 1.02, backgroundColor: 'rgba(239, 68, 68, 0.1)' }}
-                className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-red-300 hover:text-red-200 transition-colors'
+                className='flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm text-red-300 hover:bg-red-500/10'
               >
                 <LogOut size={14} />
-                <span className='text-sm'>로그아웃</span>
-              </motion.button>
+                Logout
+              </button>
             ) : (
-              <motion.button
+              <button
                 type='button'
                 onClick={() => handleNavigation('/login')}
-                whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-                className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm ${blogTheme.dropdownItem}`}
               >
                 <User size={14} />
-                <span className='text-sm'>로그인</span>
-              </motion.button>
+                Login
+              </button>
             )}
           </Dropdown>
-
-          {/* 검색 영역 */}
           <BlogSearch />
         </div>
       </motion.div>
 
-      {/* 모바일 헤더 */}
-      <div className='block lg:hidden w-full max-w-4xl mx-auto'>
+      <div className='mx-auto block w-full max-w-4xl lg:hidden'>
         <motion.div
-          className='mt-4 mb-6 mx-4 p-3 bg-black/20 backdrop-blur-md border border-blue-400/20 shadow-xl relative transition-all duration-300 rounded-full'
-          initial={{ y: -20, opacity: 0 }}
+          className={`relative mx-4 mb-6 mt-4 rounded-xl p-3 transition-all duration-300 ${blogTheme.chromeBar}`}
+          initial={{ y: -16, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.5 }}
-          style={{
-            boxShadow: `
-              0 8px 32px rgba(0, 0, 0, 0.3),
-              0 0 20px rgba(59, 130, 246, 0.2)
-            `,
-          }}
+          transition={{ duration: 0.4 }}
         >
-          {/* 네비게이션 버튼 - 좌측 상단 */}
-          <div className='absolute top-4 left-3'>
+          <span className={blogTheme.chromeShine} aria-hidden />
+          <div className='absolute left-3 top-3'>
             <Dropdown
               placement='bottom-left'
-              contentClassName='min-w-[100px]'
+              contentClassName={`min-w-[100px] ${blogTheme.dropdown}`}
               trigger={({ ref, onClick }) => (
-                <motion.button
+                <button
                   ref={ref as React.RefObject<HTMLButtonElement>}
                   type='button'
                   onClick={onClick}
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.9 }}
-                  className='p-2 rounded-full bg-gradient-to-r from-purple-500/30 to-blue-500/30 border border-blue-400/40 text-blue-100 hover:from-purple-400/40 hover:to-blue-400/40 transition-all duration-300 group'
+                  className={`rounded-lg p-2 ${blogTheme.navBtn}`}
                   title='페이지 이동'
                 >
-                  <Navigation size={14} className='group-hover:rotate-12 transition-transform duration-300' />
-                </motion.button>
+                  <Navigation size={14} className={blogTheme.textAccent} />
+                </button>
               )}
             >
-              <motion.button
+              <button
                 type='button'
                 onClick={() => handleNavigation('/')}
-                whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-                className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
               >
                 <Globe size={12} />
-                <span className='text-xs'>메인</span>
-              </motion.button>
-              <motion.button
+                Home
+              </button>
+              <button
                 type='button'
                 onClick={() => handleNavigation('/blog')}
-                whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-                className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
               >
                 <Home size={12} />
-                <span className='text-xs'>블로그</span>
-              </motion.button>
+                Blog
+              </button>
               {isAuthenticated ? (
-                <motion.button
+                <button
                   type='button'
                   onClick={handleLogout}
-                  whileHover={{ scale: 1.02, backgroundColor: 'rgba(239, 68, 68, 0.1)' }}
-                  className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-red-300 hover:text-red-200 transition-colors'
+                  className='flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-500/10'
                 >
                   <LogOut size={12} />
-                  <span className='text-xs'>로그아웃</span>
-                </motion.button>
+                  Logout
+                </button>
               ) : (
-                <motion.button
+                <button
                   type='button'
                   onClick={() => handleNavigation('/login')}
-                  whileHover={{ scale: 1.02, backgroundColor: 'rgba(59, 130, 246, 0.1)' }}
-                  className='w-full flex items-center gap-2 px-3 py-2 rounded text-left text-blue-100 hover:text-white transition-colors'
+                  className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
                 >
                   <User size={12} />
-                  <span className='text-xs'>로그인</span>
-                </motion.button>
+                  Login
+                </button>
               )}
             </Dropdown>
           </div>
 
-          <div className='flex items-center justify-between h-10 px-12'>
-            {/* 로고 - 중앙 */}
-            <motion.button
+          <div className='relative flex h-10 items-center justify-center px-12'>
+            <button
               type='button'
-              whileHover={{ scale: 1.02 }}
-              className='font-extrabold text-lg text-blue-100 flex items-center gap-2 cursor-pointer select-none hover:text-white bg-transparent border-none p-0 m-0 focus:outline-none transition-colors duration-300 flex-1 justify-center'
+              className='flex items-center gap-2 border-none bg-transparent p-0 text-base font-semibold'
+              style={syne}
             >
-              <Image src='/logo.png' alt='logo' width={24} height={24} /> 3D Tech Blog
-            </motion.button>
+              <Image src='/logo.png' alt='logo' width={22} height={22} />
+              <span className={blogTheme.titleGradient}>3D Tech Blog</span>
+            </button>
 
-            {/* 우측 버튼들 */}
-            <div className='absolute top-4 right-3 flex gap-2 items-center'>
+            <div className='absolute right-0 top-0 flex items-center gap-2'>
               <ThemeToggleButton variant='blog' className='h-8 w-8' />
-              {/* 검색 영역 */}
               <BlogSearch />
-
-              {/* 메뉴 버튼 */}
-              <motion.button
+              <button
                 type='button'
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.9 }}
-                className='p-2 rounded-full text-blue-100 hover:text-white hover:bg-white/10 transition-all duration-300'
+                className={`rounded-lg p-2 transition ${blogTheme.iconBtn}`}
                 onClick={() => setMenuOpen(true)}
                 aria-label='메뉴 열기'
               >
                 <Menu size={20} />
-              </motion.button>
+              </button>
             </div>
           </div>
         </motion.div>
       </div>
 
-      {/* 모바일/태블릿 드로어 사이드바 */}
       <MobileNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
     </>
   );

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { RecentPosts } from './RecentPosts';
 import { PostList } from './PostList';
 import { NoResults } from './NoResults';
+import { BlogSectionTitle } from './BlogSectionTitle';
 
 export const BlogMainPage = () => {
   const searchParams = useSearchParams();
@@ -39,11 +40,15 @@ export const BlogMainPage = () => {
 
   return (
     <div className='max-w-4xl mx-auto w-full'>
-      {/* 최근 포스트 섹션 */}
+      <BlogSectionTitle subtitle='최근에 올라온 글'>Recent</BlogSectionTitle>
       <RecentPosts posts={recentPosts} isLoading={isLoading} />
 
-      {/* 포스트 리스트 섹션 */}
-      <PostList posts={restPosts} isLoading={isLoading} />
+      {restPosts.length > 0 && (
+        <>
+          <BlogSectionTitle subtitle='더 많은 이야기'>Archive</BlogSectionTitle>
+          <PostList posts={restPosts} isLoading={isLoading} />
+        </>
+      )}
     </div>
   );
 };

--- a/src/widgets/post/ui/BlogSearch.tsx
+++ b/src/widgets/post/ui/BlogSearch.tsx
@@ -7,6 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useQueryState, parseAsString, parseAsArrayOf } from 'nuqs';
 import { Search, X, Filter } from 'lucide-react';
 import { useCategories } from '@/features/category/model';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import type { SearchPill } from './SearchBar';
 
 const SearchBar = dynamic(() => import('./SearchBar').then((mod) => ({ default: mod.SearchBar })), { ssr: false });
@@ -101,7 +102,7 @@ export function BlogSearch() {
               animate={{ width: 380, opacity: 1 }}
               exit={{ width: 40, opacity: 0 }}
               transition={{ type: 'spring', stiffness: 300, damping: 30, mass: 0.8 }}
-              className='flex items-center gap-2 bg-black/10 rounded-lg relative'
+              className='relative flex items-center gap-2 rounded-lg bg-[#12082a]/60 dark:bg-black/10'
             >
               <div className='flex-1 pl-2'>
                 <SearchBar
@@ -118,7 +119,7 @@ export function BlogSearch() {
                 onClick={() => setFilterOpen(!filterOpen)}
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
-                className='p-1 text-blue-100 hover:text-white transition-all duration-200 rounded-full hover:bg-white/10'
+                className={`rounded-full p-1 transition-all duration-200 ${blogTheme.searchIcon}`}
               >
                 <Filter size={16} />
               </motion.button>
@@ -127,7 +128,7 @@ export function BlogSearch() {
                 onClick={toggleSearch}
                 whileHover={{ scale: 1.1, rotate: 90 }}
                 whileTap={{ scale: 0.9 }}
-                className='p-1 mr-1 text-blue-100 hover:text-white transition-all duration-200 rounded-full hover:bg-white/10 flex-shrink-0'
+                className={`mr-1 flex-shrink-0 rounded-full p-1 transition-all duration-200 ${blogTheme.searchIcon}`}
               >
                 <X size={16} />
               </motion.button>
@@ -152,7 +153,7 @@ export function BlogSearch() {
               whileHover={{ scale: 1.1, rotate: 15 }}
               whileTap={{ scale: 0.9 }}
               transition={{ duration: 0.2 }}
-              className='p-2 rounded-full text-blue-100 hover:text-white hover:bg-white/10 transition-all duration-300'
+              className={`rounded-full p-2 transition-all duration-300 ${blogTheme.searchIcon}`}
             >
               <Search size={18} />
             </motion.button>
@@ -167,7 +168,7 @@ export function BlogSearch() {
           onClick={toggleSearch}
           whileHover={{ scale: 1.1, rotate: 15 }}
           whileTap={{ scale: 0.9 }}
-          className='p-2 rounded-full text-blue-100 hover:text-white hover:bg-white/10 transition-all duration-300'
+          className={`rounded-full p-2 transition-all duration-300 ${blogTheme.searchIcon}`}
         >
           <Search size={18} />
         </motion.button>
@@ -178,7 +179,7 @@ export function BlogSearch() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className='fixed inset-0 bg-black/50 backdrop-blur-sm z-40 flex justify-center items-start p-4'
+              className='fixed inset-0 z-40 flex items-start justify-center bg-slate-900/40 p-4 backdrop-blur-sm dark:bg-black/50'
               onClick={toggleSearch}
             >
               <motion.div
@@ -186,7 +187,7 @@ export function BlogSearch() {
                 animate={{ y: 0, opacity: 1 }}
                 exit={{ y: -20, opacity: 0 }}
                 transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className='w-full max-w-md bg-gray-800/80 backdrop-blur-xl border border-blue-400/20 rounded-2xl p-4 mt-16 shadow-2xl'
+                className={`mt-16 w-full max-w-md rounded-2xl p-4 shadow-2xl ${blogTheme.searchPanel}`}
                 onClick={(e) => e.stopPropagation()}
               >
                 <div className='flex items-center gap-2 mb-4'>
@@ -204,7 +205,7 @@ export function BlogSearch() {
                     onClick={() => setFilterOpen(!filterOpen)}
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.9 }}
-                    className='p-2 text-blue-100 hover:text-white transition-all duration-200 rounded-full hover:bg-white/10'
+                    className={`rounded-full p-2 transition-all duration-200 ${blogTheme.searchIcon}`}
                   >
                     <Filter size={20} />
                   </motion.button>

--- a/src/widgets/post/ui/BlogSectionTitle.tsx
+++ b/src/widgets/post/ui/BlogSectionTitle.tsx
@@ -1,0 +1,21 @@
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
+type BlogSectionTitleProps = {
+  children: React.ReactNode;
+  subtitle?: string;
+};
+
+export const BlogSectionTitle = ({ children, subtitle }: BlogSectionTitleProps) => {
+  return (
+    <div className='mb-6'>
+      <div className='flex items-center gap-4'>
+        <span className={blogTheme.sectionLine} aria-hidden />
+        <h2 className={blogTheme.sectionTitle} style={{ fontFamily: 'var(--font-syne), sans-serif' }}>
+          {children}
+        </h2>
+        <span className={blogTheme.sectionLineReverse} aria-hidden />
+      </div>
+      {subtitle && <p className={`mt-2 text-center text-xs ${blogTheme.textMuted}`}>{subtitle}</p>}
+    </div>
+  );
+};

--- a/src/widgets/post/ui/CategoryTree.tsx
+++ b/src/widgets/post/ui/CategoryTree.tsx
@@ -9,6 +9,7 @@ import {
   collectAncestorIds,
 } from '@/entities/category/lib/build-category-tree';
 import type { CategoryListItem } from '@/entities/category/model';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 type CategoryTreeProps = {
   categories: CategoryListItem[];
@@ -16,10 +17,7 @@ type CategoryTreeProps = {
   onSelect: (slug: string) => void;
 };
 
-const getActiveClassName = (isActive: boolean) =>
-  isActive
-    ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
-    : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0';
+const getActiveClassName = (isActive: boolean) => (isActive ? blogTheme.navActive : blogTheme.navIdle);
 
 type CategoryTreeItemProps = {
   node: CategoryTreeNode<CategoryListItem>;
@@ -48,7 +46,7 @@ const CategoryTreeItem = ({
         {hasChildren ? (
           <button
             type='button'
-            className='shrink-0 p-0.5 rounded text-blue-200 hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400'
+            className={`shrink-0 rounded p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ff9a3c]/40 dark:focus-visible:ring-[#3de8ff]/50 ${blogTheme.textMuted} hover:text-[#ff9a3c] dark:hover:text-[#3de8ff]`}
             aria-label={isExpanded ? `${node.name} 접기` : `${node.name} 펼치기`}
             aria-expanded={isExpanded}
             onClick={() => onToggle(node.id)}
@@ -60,15 +58,9 @@ const CategoryTreeItem = ({
         )}
         <motion.button
           type='button'
-          animate={{
-            boxShadow: isActive ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
-          }}
-          whileHover={{
-            scale: 1.03,
-            boxShadow: isActive ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
-          }}
+          whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.97 }}
-          className={`flex-1 flex items-center gap-2 text-left px-2 py-1 rounded-lg font-mono transition relative ${getActiveClassName(isActive)}`}
+          className={`relative flex flex-1 items-center gap-2 rounded-lg px-2 py-1 text-left text-sm transition ${getActiveClassName(isActive)}`}
           onClick={() => onSelect(node.slug)}
         >
           {hasChildren ? (

--- a/src/widgets/post/ui/MobileNavbar.tsx
+++ b/src/widgets/post/ui/MobileNavbar.tsx
@@ -1,11 +1,13 @@
 'use client';
+
+import { toCategoryListItems } from '@/entities/category';
 import { useCategories } from '@/features/category/model';
 import { useTags } from '@/features/tag/model/use-tags';
 import { Tag } from '@/features/tag/ui';
-import { toCategoryListItems } from '@/entities/category';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useMemo } from 'react';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { CategoryTree } from './CategoryTree';
 
 export const MobileNavbar = ({
@@ -19,11 +21,10 @@ export const MobileNavbar = ({
   const { data: tags } = useTags();
   const router = useRouter();
   const pathname = usePathname();
-
   const categories = useMemo(() => toCategoryListItems(data), [data]);
 
   const currentCategorySlug = (() => {
-    const match = pathname.match(/^\/blog\/category\/([^\/]+)/);
+    const match = pathname.match(/^\/blog\/category\/([^/]+)/);
     return match?.[1] ? decodeURIComponent(match[1]) : null;
   })();
   const isAllPage = pathname === '/blog/all';
@@ -42,20 +43,23 @@ export const MobileNavbar = ({
           animate={{ x: 0 }}
           exit={{ x: '100%' }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          className='fixed inset-0 z-40 bg-black/60 flex justify-end lg:hidden'
+          className={`fixed inset-0 z-40 flex justify-end backdrop-blur-sm lg:hidden ${blogTheme.overlay}`}
         >
           <motion.div
             initial={{ x: 80, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: 80, opacity: 0 }}
             transition={{ duration: 0.25 }}
-            className='w-72 max-w-full h-full flex flex-col gap-8 p-6 bg-[#181c2a]/90 border-l border-blue-300 shadow-[0_0_16px_4px_#7dd3fc55] backdrop-blur-sm overflow-y-auto'
+            className={`flex h-full w-72 max-w-full flex-col gap-8 overflow-y-auto border-l p-6 ${blogTheme.sidebar}`}
+            style={{ fontFamily: 'var(--font-syne), sans-serif' }}
           >
-            <div className='flex items-center justify-between mb-4'>
-              <span className='font-extrabold text-lg font-mono text-blue-100'>Category</span>
+            <div className='mb-4 flex items-center justify-between'>
+              <span className={`text-sm font-semibold uppercase tracking-[0.16em] ${blogTheme.labelAccent}`}>
+                Category
+              </span>
               <button
                 type='button'
-                className='text-blue-100 p-1 rounded-full hover:bg-blue-900/40'
+                className={`rounded-lg p-1 ${blogTheme.iconBtn}`}
                 onClick={() => setMenuOpen(false)}
                 aria-label='메뉴 닫기'
               >
@@ -65,29 +69,20 @@ export const MobileNavbar = ({
                 </svg>
               </button>
             </div>
-            <nav className='flex flex-col gap-2 px-3 py-4'>
+            <nav className='flex flex-col gap-2 px-1 py-2'>
               <motion.button
                 type='button'
-                animate={{
-                  boxShadow: isAllPage ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
-                }}
-                whileHover={{
-                  scale: 1.06,
-                  boxShadow: isAllPage ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
-                }}
+                whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.97 }}
-                className={`text-left px-2 py-1 rounded-lg font-mono transition relative
-                  ${
-                    isAllPage
-                      ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
-                      : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0'
-                  }`}
+                className={`rounded-lg px-2 py-1.5 text-left text-sm transition ${
+                  isAllPage ? blogTheme.navActive : blogTheme.navIdle
+                }`}
                 onClick={() => {
                   router.push('/blog/all');
                   setMenuOpen(false);
                 }}
               >
-                전체
+                All
               </motion.button>
 
               <CategoryTree
@@ -97,7 +92,9 @@ export const MobileNavbar = ({
               />
             </nav>
             <div>
-              <h2 className='font-extrabold text-base px-3 mb-2 font-mono text-blue-100'>Tags</h2>
+              <h2 className={`mb-2 px-1 text-sm font-semibold uppercase tracking-[0.16em] ${blogTheme.labelAccent}`}>
+                Tags
+              </h2>
               <div className='flex flex-wrap gap-2'>
                 {tags?.map((tag) => (
                   <Tag key={tag.id} tag={tag} count={tag.count?.posts ?? 0} />

--- a/src/widgets/post/ui/MobileNavbar.tsx
+++ b/src/widgets/post/ui/MobileNavbar.tsx
@@ -43,7 +43,7 @@ export const MobileNavbar = ({
           animate={{ x: 0 }}
           exit={{ x: '100%' }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          className={`fixed inset-0 z-40 flex justify-end backdrop-blur-sm lg:hidden ${blogTheme.overlay}`}
+          className={`fixed inset-0 z-50 flex justify-end backdrop-blur-sm lg:hidden ${blogTheme.overlay}`}
         >
           <motion.div
             initial={{ x: 80, opacity: 0 }}

--- a/src/widgets/post/ui/NoResults.tsx
+++ b/src/widgets/post/ui/NoResults.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 interface NoResultsProps {
   searchTerm?: string;
@@ -16,61 +17,31 @@ export const NoResults = ({ searchTerm, category, tags }: NoResultsProps) => {
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, ease: 'easeOut' }}
-      className='flex flex-col items-center justify-center min-h-[60vh] py-16 px-4'
+      transition={{ duration: 0.45 }}
+      className='flex min-h-[60vh] flex-col items-center justify-center px-4 py-16'
     >
-      {/* 메인 아이콘 */}
-      <motion.div
-        initial={{ scale: 0.8, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.2, duration: 0.5 }}
-        className='relative mb-6'
+      <div
+        className={`mb-6 flex h-14 w-14 items-center justify-center rounded-full border backdrop-blur-sm ${blogTheme.card}`}
       >
-        <div className='w-16 h-16 rounded-full bg-gradient-to-br from-blue-500/20 to-purple-500/20 border border-blue-400/30 flex items-center justify-center backdrop-blur-sm'>
-          <Search size={24} className='text-blue-300' />
-        </div>
-        <div className='absolute inset-0 rounded-full bg-blue-400/20 blur-xl animate-pulse' />
-      </motion.div>
+        <Search size={22} className={blogTheme.textMuted} />
+      </div>
 
-      {/* 메인 메시지 */}
-      <motion.div
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.5 }}
-        className='text-center mb-8'
+      <h2
+        className={`mb-6 text-center text-xl font-semibold ${blogTheme.textPrimary}`}
+        style={{ fontFamily: 'var(--font-syne), sans-serif' }}
       >
-        <h2 className='text-xl font-bold text-slate-100 mb-2'>
-          {hasFilters ? '검색 결과가 없습니다' : '아직 게시물이 없습니다'}
-        </h2>
-      </motion.div>
+        {hasFilters ? '검색 결과가 없습니다' : '아직 게시물이 없습니다'}
+      </h2>
 
-      {/* 액션 버튼 */}
-      <motion.button
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.4, duration: 0.5 }}
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.95 }}
+      <button
+        type='button'
         onClick={() => router.push('/blog/all')}
-        className='px-6 py-2 rounded-lg bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/30 text-blue-300 hover:from-blue-500/30 hover:to-purple-500/30 hover:border-blue-400/50 transition-all duration-300 backdrop-blur-sm'
+        className={`rounded-lg border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-6 py-2 text-sm transition hover:border-[#ff9a3c]/50 hover:bg-[#ff9a3c]/15 dark:border-[#3de8ff]/30 dark:bg-[#3de8ff]/8 dark:hover:border-[#3de8ff]/50 dark:hover:bg-[#3de8ff]/12 ${blogTheme.textAccent}`}
       >
         전체 게시물 보기
-      </motion.button>
-
-      {/* 장식적 요소들 */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.8, duration: 1 }}
-        className='absolute inset-0 pointer-events-none overflow-hidden'
-      >
-        {/* 배경 장식 */}
-        <div className='absolute top-1/4 left-1/4 w-32 h-32 rounded-full bg-blue-500/5 blur-3xl' />
-        <div className='absolute bottom-1/4 right-1/4 w-24 h-24 rounded-full bg-purple-500/5 blur-2xl' />
-        <div className='absolute top-1/2 right-1/3 w-16 h-16 rounded-full bg-cyan-500/5 blur-xl' />
-      </motion.div>
+      </button>
     </motion.div>
   );
 };

--- a/src/widgets/post/ui/PostBackButton.tsx
+++ b/src/widgets/post/ui/PostBackButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
+type PostBackButtonProps = {
+  href: string;
+  label?: string;
+};
+
+export const PostBackButton = ({ href, label = '목록으로' }: PostBackButtonProps) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push(href);
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className={`mb-4 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition ${blogTheme.navBtn}`}
+      aria-label={`${label}로 돌아가기`}
+    >
+      <ArrowLeft size={16} className={blogTheme.textAccent} aria-hidden />
+      <span className={blogTheme.textPrimary}>{label}</span>
+    </button>
+  );
+};

--- a/src/widgets/post/ui/PostList.tsx
+++ b/src/widgets/post/ui/PostList.tsx
@@ -1,6 +1,6 @@
-import { PostListCardSkeleton } from '@/shared/ui/skeleton';
-import { PostListCard } from '@/features/blog/ui';
 import type { PostResponse } from '@/entities/post/model/post';
+import { PostListCard } from '@/features/blog/ui';
+import { PostListCardSkeleton } from '@/shared/ui/skeleton';
 
 type PostListProps = {
   posts: PostResponse[];
@@ -10,9 +10,9 @@ type PostListProps = {
 export const PostList = ({ posts, isLoading }: PostListProps) => {
   if (isLoading) {
     return (
-      <div className='flex flex-col gap-8'>
-        {Array.from({ length: 5 }).map((_) => (
-          <PostListCardSkeleton key={`skeleton-list-${Math.random()}`} />
+      <div className='flex flex-col gap-8' aria-busy='true'>
+        {['a', 'b', 'c', 'd', 'e'].map((id) => (
+          <PostListCardSkeleton key={`skeleton-list-${id}`} />
         ))}
       </div>
     );

--- a/src/widgets/post/ui/PostsLayoutShell.tsx
+++ b/src/widgets/post/ui/PostsLayoutShell.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Suspense } from 'react';
+import { SpaceBackground } from '@/widgets/post/ui';
+import BlogHeader from '@/widgets/post/ui/BlogHeader';
+import Sidebar from '@/widgets/post/ui/Sidebar';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
+type PostsLayoutShellProps = {
+  children: React.ReactNode;
+};
+
+export const PostsLayoutShell = ({ children }: PostsLayoutShellProps) => {
+  return (
+    <main className={blogTheme.shellRoot}>
+      <div className={`relative h-screen w-full overflow-hidden ${blogTheme.shell}`}>
+        <SpaceBackground />
+
+        <div className='relative z-10 flex h-screen'>
+          <main className='flex flex-1 justify-center overflow-y-auto p-4 lg:p-10'>
+            <div className='w-full'>
+              <Suspense fallback={<div className='mx-auto mb-8 h-16 w-full max-w-4xl' />}>
+                <BlogHeader />
+              </Suspense>
+              {children}
+            </div>
+          </main>
+
+          <Suspense fallback={null}>
+            <Sidebar />
+          </Suspense>
+        </div>
+
+        <div
+          className={`pointer-events-none absolute inset-x-0 bottom-0 z-[5] h-[32vh] ${blogTheme.bottomVeil}`}
+          aria-hidden
+        />
+      </div>
+    </main>
+  );
+};

--- a/src/widgets/post/ui/PostsLayoutShell.tsx
+++ b/src/widgets/post/ui/PostsLayoutShell.tsx
@@ -12,7 +12,7 @@ type PostsLayoutShellProps = {
 
 export const PostsLayoutShell = ({ children }: PostsLayoutShellProps) => {
   return (
-    <main className={blogTheme.shellRoot}>
+    <div className={blogTheme.shellRoot}>
       <div className={`relative h-screen w-full overflow-hidden ${blogTheme.shell}`}>
         <SpaceBackground />
 
@@ -36,6 +36,6 @@ export const PostsLayoutShell = ({ children }: PostsLayoutShellProps) => {
           aria-hidden
         />
       </div>
-    </main>
+    </div>
   );
 };

--- a/src/widgets/post/ui/RecentPosts.tsx
+++ b/src/widgets/post/ui/RecentPosts.tsx
@@ -6,6 +6,7 @@ import type { PostResponse } from '@/entities/post/model/post';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { LoaderCircle } from 'lucide-react';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 type RecentPostsProps = {
   posts: PostResponse[];
@@ -36,6 +37,7 @@ export const RecentPosts = ({ posts, isLoading }: RecentPostsProps) => {
   return (
     <div className='grid grid-cols-2 sm:grid-cols-3 gap-4 mb-10'>
       {recentPosts.map((post, idx) => {
+        const postKey = post.id ?? post.slug ?? `recent-${idx}`;
         const href = `/blog/category/${post.category?.slug}/post/${post.slug}`;
         const isCardPending = isPending && pendingHref === href;
 
@@ -54,7 +56,7 @@ export const RecentPosts = ({ posts, isLoading }: RecentPostsProps) => {
         return (
           <Link
             href={href}
-            key={post.id ?? post.createdAt}
+            key={postKey}
             prefetch
             onClick={handleNavigate}
             onMouseEnter={() => {
@@ -68,14 +70,15 @@ export const RecentPosts = ({ posts, isLoading }: RecentPostsProps) => {
             }`}
           >
             {isCardPending && (
-              <span className='absolute right-3 top-3 z-20 text-cyan-300' aria-hidden>
+              <span className={`absolute right-3 top-3 z-20 ${blogTheme.textAccent}`} aria-hidden>
                 <LoaderCircle className='size-4 animate-spin' />
               </span>
             )}
             <AnimatePresence>
               {hoveredIndex === idx && (
                 <motion.span
-                  className='absolute inset-0 h-full w-full bg-slate-600/60 dark:bg-[#232946]/95 backdrop-blur-md block rounded-3xl pointer-events-none'
+                  key={`hover-${postKey}`}
+                  className='pointer-events-none absolute inset-0 block h-full w-full rounded-xl bg-[#ff9a3c]/8 backdrop-blur-md dark:bg-[#3de8ff]/8'
                   layoutId='hoverBackground'
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1, transition: { duration: 0.15 } }}
@@ -83,8 +86,8 @@ export const RecentPosts = ({ posts, isLoading }: RecentPostsProps) => {
                   style={{ willChange: 'opacity, background' }}
                 />
               )}
-              <PostCard post={post} />
             </AnimatePresence>
+            <PostCard post={post} />
           </Link>
         );
       })}

--- a/src/widgets/post/ui/Sidebar.tsx
+++ b/src/widgets/post/ui/Sidebar.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useTags } from '@/features/tag/model/use-tags';
-import { Tag } from '@/features/tag/ui';
+import { toCategoryListItems } from '@/entities/category';
 import { VisitorCounter } from '@/features/blog/ui';
 import { useCategories } from '@/features/category/model';
-import { toCategoryListItems } from '@/entities/category';
+import { useTags } from '@/features/tag/model/use-tags';
+import { Tag } from '@/features/tag/ui';
+import { SidebarSkeleton } from '@/shared/ui/skeleton';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
-import { SparklesCore } from '@/shared/ui/sparkles';
-import { SidebarSkeleton } from '@/shared/ui/skeleton';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { CategoryTree } from './CategoryTree';
 
 export default function Sidebar() {
@@ -18,14 +18,11 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { data, isLoading } = useCategories();
   const [sidebarOpen, setSidebarOpen] = useState(true);
-
   const { data: tags } = useTags();
-
   const categories = useMemo(() => toCategoryListItems(data), [data]);
 
-  // pathname에서 category slug 추출 (/blog/category/react -> react)
   const currentCategorySlug = (() => {
-    const match = pathname.match(/^\/blog\/category\/([^\/]+)/);
+    const match = pathname.match(/^\/blog\/category\/([^/]+)/);
     return match?.[1] ? decodeURIComponent(match[1]) : null;
   })();
   const isAllPage = pathname === '/blog/all';
@@ -36,21 +33,6 @@ export default function Sidebar() {
 
   return (
     <>
-      {/* SparklesCore - 데스크톱에서만 표시 */}
-      <div className='hidden lg:block'>
-        <SparklesCore
-          background='transparent'
-          minSize={0.3}
-          maxSize={0.8}
-          particleDensity={300}
-          className={`fixed top-0 w-8 h-full pointer-events-none z-5 transition-all duration-300 ${
-            sidebarOpen ? 'right-80' : 'right-0'
-          }`}
-          particleColor='#7dd3fc'
-          speed={2}
-        />
-      </div>
-
       <AnimatePresence>
         {sidebarOpen && (
           <motion.aside
@@ -58,49 +40,39 @@ export default function Sidebar() {
             initial={{ x: '100%', opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '100%', opacity: 0 }}
-            transition={{ type: 'tween', duration: 0.35, ease: 'easeInOut' }}
-            className='hidden lg:flex h-screen flex-shrink-0 flex-col gap-8 w-80 p-6 bg-[#181c2a]/80 border-l border-blue-300 shadow-[0_0_16px_4px_#7dd3fc55] backdrop-blur-sm z-10 relative'
-            style={{ minWidth: 320 }}
+            transition={{ type: 'tween', duration: 0.3, ease: 'easeInOut' }}
+            className={`relative z-10 hidden h-screen w-80 flex-shrink-0 flex-col gap-8 p-6 lg:flex ${blogTheme.sidebar}`}
+            style={{ minWidth: 320, fontFamily: 'var(--font-syne), sans-serif' }}
           >
-            {/* 접기 버튼 (사이드바 내부 오른쪽 상단) */}
             <button
               type='button'
-              className='absolute top-4 left-[-44px] z-20 p-0 m-0 bg-none border-none outline-none text-blue-100 hover:text-blue-400 focus:text-blue-400 transition drop-shadow-[0_0_8px_#7dd3fc55] hover:drop-shadow-[0_0_12px_#7dd3fc] focus:drop-shadow-[0_0_12px_#7dd3fc]'
+              className={`absolute left-[-40px] top-4 z-20 m-0 border-none bg-transparent p-0 outline-none transition hover:text-[#3de8ff] ${blogTheme.textMuted}`}
               onClick={() => setSidebarOpen(false)}
               aria-label='사이드바 접기'
-              style={{ fontSize: 32, lineHeight: 1 }}
             >
-              <ChevronRight size={32} />
+              <ChevronRight size={28} />
             </button>
-            {/* 사이드바 내용 */}
+
             <div>
               <VisitorCounter />
-              <div className='px-3 py-2 flex items-center justify-between'>
-                <span className='font-extrabold text-lg font-mono text-blue-100'>Category</span>
+              <div className='mb-3 flex items-center gap-2 px-3'>
+                <span className={`h-px flex-1 ${blogTheme.sectionLine}`} aria-hidden />
+                <span className={`text-sm font-semibold uppercase tracking-[0.16em] ${blogTheme.labelAccent}`}>
+                  Category
+                </span>
+                <span className={`h-px flex-1 ${blogTheme.sectionLineReverse}`} aria-hidden />
               </div>
               <nav className='flex flex-col gap-2 px-3 py-4'>
-                {/* 전체 메뉴 */}
                 <motion.button
                   type='button'
-                  animate={{
-                    boxShadow: isAllPage ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : 'none',
-                  }}
-                  whileHover={{
-                    scale: 1.06,
-                    boxShadow: isAllPage ? '0 0 12px #7dd3fc, 0 0 24px #7dd3fc55' : '0 0 8px #7dd3fc55',
-                  }}
-                  whileTap={{ scale: 0.97 }}
-                  className={`text-left px-2 py-1 rounded-lg font-mono transition relative
-                      ${
-                        isAllPage
-                          ? 'bg-blue-100 text-[#232946] border border-blue-300 shadow-[0_0_12px_#7dd3fc,0_0_24px_#7dd3fc55]'
-                          : 'bg-transparent hover:bg-blue-900/40 text-blue-100 border-0'
-                      }`}
-                  onClick={() => {
-                    router.push('/blog/all');
-                  }}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className={`rounded-lg px-2 py-1.5 text-left text-sm transition ${
+                    isAllPage ? blogTheme.navActive : blogTheme.navIdle
+                  }`}
+                  onClick={() => router.push('/blog/all')}
                 >
-                  전체
+                  All
                 </motion.button>
 
                 <CategoryTree
@@ -110,8 +82,13 @@ export default function Sidebar() {
                 />
               </nav>
             </div>
+
             <div>
-              <h2 className='font-extrabold text-base px-3 mb-2 font-mono text-blue-100'>Tags</h2>
+              <div className='mb-3 flex items-center gap-2 px-3'>
+                <span className={`h-px flex-1 ${blogTheme.sectionLine}`} aria-hidden />
+                <h2 className={`text-sm font-semibold uppercase tracking-[0.16em] ${blogTheme.labelAccent}`}>Tags</h2>
+                <span className={`h-px flex-1 ${blogTheme.sectionLineReverse}`} aria-hidden />
+              </div>
               <div className='flex flex-wrap gap-2'>
                 {tags?.map((tag) => (
                   <Tag key={tag.id} tag={tag} count={tag.count?.posts ?? 0} />
@@ -121,15 +98,15 @@ export default function Sidebar() {
           </motion.aside>
         )}
       </AnimatePresence>
+
       {!sidebarOpen && (
         <button
           type='button'
-          className='hidden lg:flex fixed top-1/2 right-0 z-30 p-0 m-0 bg-none border-none outline-none text-blue-100 hover:text-blue-400 focus:text-blue-400 transition drop-shadow-[0_0_8px_#7dd3fc55] hover:drop-shadow-[0_0_12px_#7dd3fc] focus:drop-shadow-[0_0_12px_#7dd3fc]'
+          className={`fixed right-0 top-1/2 z-30 hidden -translate-y-1/2 border-none bg-transparent p-0 outline-none transition hover:text-[#3de8ff] lg:flex ${blogTheme.textMuted}`}
           onClick={() => setSidebarOpen(true)}
           aria-label='사이드바 열기'
-          style={{ fontSize: 32, lineHeight: 1, transform: 'translateY(-50%)' }}
         >
-          <ChevronLeft size={32} />
+          <ChevronLeft size={28} />
         </button>
       )}
     </>

--- a/src/widgets/post/ui/Sidebar.tsx
+++ b/src/widgets/post/ui/Sidebar.tsx
@@ -46,7 +46,7 @@ export default function Sidebar() {
           >
             <button
               type='button'
-              className={`absolute left-[-40px] top-4 z-20 m-0 border-none bg-transparent p-0 outline-none transition hover:text-[#3de8ff] ${blogTheme.textMuted}`}
+              className={`absolute left-[-40px] top-4 z-20 m-0 border-none bg-transparent p-0 outline-none transition hover:text-[#ff9a3c] dark:hover:text-[#3de8ff] ${blogTheme.textMuted}`}
               onClick={() => setSidebarOpen(false)}
               aria-label='사이드바 접기'
             >
@@ -102,7 +102,7 @@ export default function Sidebar() {
       {!sidebarOpen && (
         <button
           type='button'
-          className={`fixed right-0 top-1/2 z-30 hidden -translate-y-1/2 border-none bg-transparent p-0 outline-none transition hover:text-[#3de8ff] lg:flex ${blogTheme.textMuted}`}
+          className={`fixed right-0 top-1/2 z-30 hidden -translate-y-1/2 border-none bg-transparent p-0 outline-none transition hover:text-[#ff9a3c] dark:hover:text-[#3de8ff] lg:flex ${blogTheme.textMuted}`}
           onClick={() => setSidebarOpen(true)}
           aria-label='사이드바 열기'
         >

--- a/src/widgets/post/ui/SpaceBackground.tsx
+++ b/src/widgets/post/ui/SpaceBackground.tsx
@@ -2,190 +2,274 @@
 
 import { motion } from 'framer-motion';
 
-// Tailwind 색상 클래스 배열
-const colorClasses = [
-  'bg-white',
-  'bg-blue-400',
-  'bg-purple-400',
-  'bg-pink-400',
-  'bg-yellow-400',
-  'bg-cyan-400',
-  'bg-fuchsia-400',
-];
-// 별 60개, 색상 랜덤
-const stars = Array.from({ length: 100 }).map((_, i) => {
-  const color = colorClasses[i % colorClasses.length];
-  const size = `${Math.random() * 2 + 1}px`;
-  const top = `${Math.random() * 100}%`;
-  const left = `${Math.random() * 100}%`;
-  const opacity = Math.random() * 0.7 + 0.3;
-  const duration = `${2 + Math.random() * 2}s`;
-  const delay = `${Math.random() * 2}s`;
+const twilightStars = Array.from({ length: 40 }).map((_, i) => {
+  const size = `${(i % 3) * 0.5 + 1.2}px`;
+  const top = `${(i * 19) % 100}%`;
+  const left = `${(i * 31) % 100}%`;
+  const opacity = 0.25 + ((i * 11) % 50) / 100;
   return (
     <span
-      key={`star-${Math.random()}`}
-      className={`absolute block rounded-full ${color} shadow-[0_0_8px_2px_#7dd3fc88] animate-pulse`}
+      key={`star-light-${Math.random()}`}
+      className='absolute block rounded-full bg-[#ffc8a0] dark:hidden'
       style={{
         width: size,
         height: size,
         top,
         left,
         opacity,
-        animationDuration: duration,
-        animationDelay: delay,
+        boxShadow: '0 0 6px rgba(255, 200, 160, 0.35)',
       }}
     />
   );
 });
 
-// 행성 생성
-const planets = [
+const darkStars = Array.from({ length: 90 }).map((_, i) => {
+  const size = `${(i % 4) * 0.35 + 0.8}px`;
+  const top = `${(i * 17) % 100}%`;
+  const left = `${(i * 29) % 100}%`;
+  const opacity = 0.2 + ((i * 13) % 60) / 100;
+  return (
+    <span
+      key={`star-dark-${Math.random()}`}
+      className='absolute hidden rounded-full bg-[#7ec8ff] dark:block'
+      style={{
+        width: size,
+        height: size,
+        top,
+        left,
+        opacity,
+        boxShadow: '0 0 8px rgba(61, 232, 255, 0.3)',
+      }}
+    />
+  );
+});
+
+type PlanetPalette = {
+  sphere: string;
+  bands?: string;
+  atmosphere: string;
+  ringStroke?: string;
+  ringFill?: string;
+};
+
+type PlanetConfig = {
+  id: string;
+  size: number;
+  top: string;
+  left: string;
+  floatDuration: number;
+  driftDuration: number;
+  hasRing?: boolean;
+  light: PlanetPalette;
+  dark: PlanetPalette;
+};
+
+const planets: PlanetConfig[] = [
   {
-    id: 'planet-1',
-    size: 80,
-    top: '15%',
-    left: '85%',
-    color: 'from-red-500 to-orange-500',
-    ringColor: 'border-yellow-500/20',
-    ringSize: 100,
-    duration: 120,
+    id: 'ember-giant',
+    size: 68,
+    top: '11%',
+    left: '86%',
+    floatDuration: 9,
+    driftDuration: 240,
+    hasRing: true,
+    light: {
+      sphere: 'radial-gradient(circle at 32% 28%, #ffd4a8 0%, #ff9a3c 28%, #c44d2a 62%, #3a1428 100%)',
+      bands:
+        'repeating-linear-gradient(175deg, transparent 0px, transparent 7px, rgba(255,220,180,0.07) 7px, rgba(255,220,180,0.07) 9px)',
+      atmosphere: 'rgba(255, 154, 60, 0.28)',
+      ringStroke: 'rgba(255, 200, 140, 0.35)',
+      ringFill: 'rgba(255, 180, 100, 0.06)',
+    },
+    dark: {
+      sphere: 'radial-gradient(circle at 32% 28%, #9ee8ff 0%, #3de8ff 24%, #1a6a9a 58%, #061428 100%)',
+      bands:
+        'repeating-linear-gradient(168deg, transparent 0px, transparent 6px, rgba(180,240,255,0.08) 6px, rgba(180,240,255,0.08) 8px)',
+      atmosphere: 'rgba(61, 232, 255, 0.22)',
+      ringStroke: 'rgba(126, 200, 255, 0.3)',
+      ringFill: 'rgba(61, 232, 255, 0.05)',
+    },
   },
   {
-    id: 'planet-2',
-    size: 40,
-    top: '70%',
-    left: '10%',
-    color: 'from-blue-500 to-purple-500',
-    ringColor: 'border-indigo-500/20',
-    ringSize: 55,
-    duration: 180,
+    id: 'dusk-moon',
+    size: 30,
+    top: '72%',
+    left: '9%',
+    floatDuration: 7,
+    driftDuration: 320,
+    light: {
+      sphere: 'radial-gradient(circle at 35% 30%, #f0d0c0 0%, #b88878 35%, #5a3848 72%, #1a0e18 100%)',
+      atmosphere: 'rgba(200, 140, 120, 0.12)',
+    },
+    dark: {
+      sphere: 'radial-gradient(circle at 35% 30%, #c8d8e8 0%, #788898 38%, #384858 74%, #0a0e14 100%)',
+      atmosphere: 'rgba(126, 200, 255, 0.1)',
+    },
   },
   {
-    id: 'planet-3',
-    size: 60,
+    id: 'violet-core',
+    size: 48,
     top: '30%',
-    left: '20%',
-    color: 'from-green-400 to-blue-400',
-    ringColor: 'border-green-300/20',
-    ringSize: 80,
-    duration: 150,
+    left: '14%',
+    floatDuration: 11,
+    driftDuration: 280,
+    hasRing: true,
+    light: {
+      sphere: 'radial-gradient(circle at 30% 26%, #f0c0e8 0%, #c878a8 30%, #6a2868 65%, #180818 100%)',
+      atmosphere: 'rgba(200, 120, 180, 0.2)',
+      ringStroke: 'rgba(232, 160, 200, 0.25)',
+      ringFill: 'rgba(200, 120, 180, 0.04)',
+    },
+    dark: {
+      sphere: 'radial-gradient(circle at 30% 26%, #c0d0ff 0%, #6366f1 32%, #312e81 68%, #0a0618 100%)',
+      atmosphere: 'rgba(99, 102, 241, 0.22)',
+      ringStroke: 'rgba(129, 140, 248, 0.28)',
+      ringFill: 'rgba(99, 102, 241, 0.05)',
+    },
   },
   {
-    id: 'planet-4',
-    size: 50,
-    top: '60%',
-    left: '70%',
-    color: 'from-yellow-400 to-pink-400',
-    ringColor: 'border-pink-300/20',
-    ringSize: 65,
-    duration: 100,
-  },
-  {
-    id: 'planet-5',
-    size: 35,
-    top: '40%',
-    left: '55%',
-    color: 'from-fuchsia-400 to-purple-500',
-    ringColor: 'border-fuchsia-300/20',
-    ringSize: 50,
-    duration: 90,
+    id: 'horizon-pebble',
+    size: 22,
+    top: '52%',
+    left: '78%',
+    floatDuration: 6,
+    driftDuration: 360,
+    light: {
+      sphere: 'radial-gradient(circle at 38% 32%, #ffe0b8 0%, #e89050 40%, #804020 100%)',
+      atmosphere: 'rgba(255, 180, 100, 0.15)',
+    },
+    dark: {
+      sphere: 'radial-gradient(circle at 38% 32%, #b8e8ff 0%, #4898c8 42%, #183858 100%)',
+      atmosphere: 'rgba(61, 232, 255, 0.12)',
+    },
   },
 ];
 
-export const SpaceBackground = () => {
-  // 행성/은하수 등 추가
+const PlanetRing = ({ size, stroke, fill }: { size: number; stroke: string; fill: string }) => {
+  const w = size * 2.15;
+  const h = size * 0.72;
   return (
-    <div className='absolute inset-0 z-10 pointer-events-none'>
-      {/* 별 */}
-      {stars}
-      {/* 행성들 */}
-      {planets.map((planet) => (
-        <motion.div
-          key={planet.id}
-          className='absolute'
-          style={{
-            top: planet.top,
-            left: planet.left,
-          }}
-          initial={{ rotate: 0 }}
-          animate={{ rotate: 360 }}
-          transition={{
-            duration: planet.duration,
-            repeat: Number.POSITIVE_INFINITY,
-            ease: 'linear',
-          }}
-        >
-          {/* 행성 고리 */}
-          {planet.ringSize && (
-            <div
-              className={`absolute rounded-full border-4 ${planet.ringColor}`}
-              style={{
-                width: planet.ringSize,
-                height: planet.ringSize / 2,
-                top: planet.size / 2 - planet.ringSize / 4,
-                left: planet.size / 2 - planet.ringSize / 2,
-                transform: 'rotateX(75deg)',
-              }}
-            />
-          )}
+    <svg
+      className='pointer-events-none absolute left-1/2 top-[58%] -translate-x-1/2 -translate-y-1/2'
+      width={w}
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
+      aria-hidden='true'
+    >
+      <ellipse cx={w / 2} cy={h / 2} rx={w / 2 - 2} ry={h / 2 - 2} fill={fill} />
+      <ellipse cx={w / 2} cy={h / 2} rx={w / 2 - 2} ry={h / 2 - 2} fill='none' stroke={stroke} strokeWidth='1.5' />
+      <ellipse
+        cx={w / 2}
+        cy={h / 2}
+        rx={w / 2 - 8}
+        ry={h / 2 - 5}
+        fill='none'
+        stroke={stroke}
+        strokeWidth='0.75'
+        opacity='0.5'
+      />
+    </svg>
+  );
+};
 
-          {/* 행성 본체 */}
-          <motion.div
-            className={`absolute rounded-full bg-gradient-to-br ${planet.color}`}
-            style={{
-              width: planet.size,
-              height: planet.size,
-            }}
-            animate={{ rotate: -360 }}
-            transition={{
-              duration: planet.duration * 0.8,
-              repeat: Number.POSITIVE_INFINITY,
-              ease: 'linear',
-            }}
-          >
-            {/* 행성 표면 특징 */}
-            <div className='absolute w-3/4 h-1/2 bg-white/10 rounded-full top-1/4 left-1/8' />
-          </motion.div>
-        </motion.div>
-      ))}
-      {/* 은하수 느낌의 그라데이션 */}
-      <div className='absolute inset-0 pointer-events-none -z-10'>
-        {/* 여러 개의 큰 은하수 레이어 */}
-        {Array.from({ length: 5 }).map((_, i) => {
-          // 랜덤 위치, 각도, 색상, 투명도, 크기
-          const top = `${40 + Math.random() * 20}%`;
-          const left = `${10 + Math.random() * 60}%`;
-          const width = `${320 + Math.random() * 160}px`;
-          const height = `${24 + Math.random() * 24}px`;
-          const rotate = `${-15 + Math.random() * 30}`;
-          const opacity = 0.08 + Math.random() * 0.18;
-          // Tailwind 지원 색상 조합
-          const gradients = [
-            'from-blue-200 via-white to-pink-200',
-            'from-fuchsia-200 via-white to-blue-200',
-            'from-purple-200 via-blue-100 to-pink-100',
-            'from-cyan-200 via-white to-fuchsia-200',
-            'from-blue-300 via-white to-purple-200',
-          ];
-          const gradient = gradients[i % gradients.length];
-          return (
-            <span
-              key={`milkyway-${i}-${Math.random()}`}
-              className={`absolute rounded-full blur-3xl bg-gradient-to-r ${gradient}`}
-              style={{
-                top,
-                left,
-                width,
-                height,
-                opacity,
-                transform: `rotate(${rotate}deg)`,
-              }}
-            />
-          );
-        })}
-        <div className='absolute top-1/4 left-1/4 w-1/2 h-1/2 rounded-full bg-purple-500/20 blur-3xl' />
-        <div className='absolute bottom-0 right-0 w-1/3 h-1/3 rounded-full bg-pink-500/20 blur-3xl' />
+const PlanetSphere = ({ size, palette }: { size: number; palette: PlanetPalette }) => {
+  return (
+    <motion.div
+      className='relative overflow-hidden rounded-full'
+      style={{ width: size, height: size }}
+      animate={{ rotate: 360 }}
+      transition={{ duration: 280, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
+    >
+      <div className='absolute inset-0 rounded-full' style={{ background: palette.sphere }} />
+      {palette.bands && (
+        <div className='absolute inset-0 rounded-full opacity-80' style={{ background: palette.bands }} />
+      )}
+      {/* terminator */}
+      <div
+        className='absolute inset-0 rounded-full'
+        style={{
+          background:
+            'radial-gradient(circle at 72% 50%, transparent 36%, rgba(0,0,0,0.15) 58%, rgba(0,0,0,0.55) 100%)',
+        }}
+      />
+      {/* specular */}
+      <div className='absolute left-[16%] top-[14%] h-[20%] w-[26%] rounded-full bg-white/30 blur-[1px]' />
+      <div className='absolute left-[22%] top-[20%] h-[8%] w-[10%] rounded-full bg-white/50' />
+    </motion.div>
+  );
+};
+
+const Planet = ({ planet }: { planet: PlanetConfig }) => {
+  return (
+    <motion.div
+      className='absolute'
+      style={{ top: planet.top, left: planet.left, width: planet.size, height: planet.size }}
+      animate={{ y: [0, -8, 0] }}
+      transition={{
+        duration: planet.floatDuration,
+        repeat: Number.POSITIVE_INFINITY,
+        ease: 'easeInOut',
+      }}
+      aria-hidden
+    >
+      {/* Light theme */}
+      <div className='absolute inset-0 dark:hidden' style={{ width: planet.size, height: planet.size }}>
+        <div
+          className='absolute inset-[-35%] rounded-full blur-2xl'
+          style={{ background: `radial-gradient(circle, ${planet.light.atmosphere} 0%, transparent 70%)` }}
+        />
+        {planet.hasRing && planet.light.ringStroke && (
+          <PlanetRing
+            size={planet.size}
+            stroke={planet.light.ringStroke}
+            fill={planet.light.ringFill ?? 'transparent'}
+          />
+        )}
+        <div className='absolute left-0 top-0'>
+          <PlanetSphere size={planet.size} palette={planet.light} />
+        </div>
       </div>
+
+      {/* Dark theme */}
+      <div className='absolute inset-0 hidden dark:block' style={{ width: planet.size, height: planet.size }}>
+        <div
+          className='absolute inset-[-35%] rounded-full blur-2xl'
+          style={{ background: `radial-gradient(circle, ${planet.dark.atmosphere} 0%, transparent 70%)` }}
+        />
+        {planet.hasRing && planet.dark.ringStroke && (
+          <PlanetRing size={planet.size} stroke={planet.dark.ringStroke} fill={planet.dark.ringFill ?? 'transparent'} />
+        )}
+        <div className='absolute left-0 top-0'>
+          <PlanetSphere size={planet.size} palette={planet.dark} />
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export const SpaceBackground = () => {
+  return (
+    <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden' aria-hidden>
+      <div className='absolute inset-x-0 bottom-0 h-[45vh] bg-gradient-to-t from-[#ff9a3c]/25 via-[#8a4a68]/15 to-transparent dark:hidden' />
+      <div className='absolute bottom-[-10%] left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[#ffc090]/30 blur-3xl dark:hidden' />
+      <div className='absolute inset-0 hidden bg-gradient-to-b from-[#000010]/80 via-transparent to-[#000008]/60 dark:block' />
+
+      <div className='absolute inset-0 opacity-60 dark:opacity-80'>
+        <span className='absolute left-[8%] top-[38%] h-5 w-80 rotate-[-12deg] rounded-full bg-gradient-to-r from-orange-200/20 via-white/10 to-rose-200/15 blur-2xl dark:from-blue-300/10 dark:via-white/8 dark:to-purple-300/10' />
+        <span className='absolute left-[30%] top-[48%] h-4 w-96 rotate-[8deg] rounded-full bg-gradient-to-r from-amber-200/15 via-white/8 to-fuchsia-200/12 blur-2xl dark:from-cyan-300/8 dark:via-white/6 dark:to-indigo-300/10' />
+      </div>
+
+      {twilightStars}
+      {darkStars}
+
+      <div className='absolute -left-32 top-[10%] h-96 w-96 rounded-full bg-[#8a4a68]/20 blur-3xl dark:bg-[#3de8ff]/6' />
+      <div className='absolute -right-24 top-[30%] h-72 w-72 rounded-full bg-[#ffc090]/15 blur-3xl dark:bg-[#6366f1]/8' />
+      <div className='absolute bottom-[20%] left-[20%] h-64 w-64 rounded-full bg-[#c878ff]/10 blur-3xl dark:hidden' />
+      <div className='absolute right-[10%] top-[15%] hidden h-56 w-56 rounded-full bg-[#3de8ff]/5 blur-3xl dark:block' />
+
+      {planets.map((planet) => (
+        <Planet key={planet.id} planet={planet} />
+      ))}
     </div>
   );
 };

--- a/src/widgets/post/ui/SpaceBackground.tsx
+++ b/src/widgets/post/ui/SpaceBackground.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 
 const twilightStars = Array.from({ length: 40 }).map((_, i) => {
   const size = `${(i % 3) * 0.5 + 1.2}px`;
@@ -9,7 +11,7 @@ const twilightStars = Array.from({ length: 40 }).map((_, i) => {
   const opacity = 0.25 + ((i * 11) % 50) / 100;
   return (
     <span
-      key={`star-light-${Math.random()}`}
+      key={`star-light-${i}`}
       className='absolute block rounded-full bg-[#ffc8a0] dark:hidden'
       style={{
         width: size,
@@ -30,7 +32,7 @@ const darkStars = Array.from({ length: 90 }).map((_, i) => {
   const opacity = 0.2 + ((i * 13) % 60) / 100;
   return (
     <span
-      key={`star-dark-${Math.random()}`}
+      key={`star-dark-${i}`}
       className='absolute hidden rounded-full bg-[#7ec8ff] dark:block'
       style={{
         width: size,
@@ -172,19 +174,26 @@ const PlanetRing = ({ size, stroke, fill }: { size: number; stroke: string; fill
   );
 };
 
-const PlanetSphere = ({ size, palette }: { size: number; palette: PlanetPalette }) => {
+const PlanetSphere = ({
+  size,
+  palette,
+  driftDuration,
+}: {
+  size: number;
+  palette: PlanetPalette;
+  driftDuration: number;
+}) => {
   return (
     <motion.div
       className='relative overflow-hidden rounded-full'
       style={{ width: size, height: size }}
       animate={{ rotate: 360 }}
-      transition={{ duration: 280, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
+      transition={{ duration: driftDuration, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
     >
       <div className='absolute inset-0 rounded-full' style={{ background: palette.sphere }} />
       {palette.bands && (
         <div className='absolute inset-0 rounded-full opacity-80' style={{ background: palette.bands }} />
       )}
-      {/* terminator */}
       <div
         className='absolute inset-0 rounded-full'
         style={{
@@ -192,14 +201,15 @@ const PlanetSphere = ({ size, palette }: { size: number; palette: PlanetPalette 
             'radial-gradient(circle at 72% 50%, transparent 36%, rgba(0,0,0,0.15) 58%, rgba(0,0,0,0.55) 100%)',
         }}
       />
-      {/* specular */}
       <div className='absolute left-[16%] top-[14%] h-[20%] w-[26%] rounded-full bg-white/30 blur-[1px]' />
       <div className='absolute left-[22%] top-[20%] h-[8%] w-[10%] rounded-full bg-white/50' />
     </motion.div>
   );
 };
 
-const Planet = ({ planet }: { planet: PlanetConfig }) => {
+const Planet = ({ planet, isDark }: { planet: PlanetConfig; isDark: boolean }) => {
+  const palette = isDark ? planet.dark : planet.light;
+
   return (
     <motion.div
       className='absolute'
@@ -212,35 +222,16 @@ const Planet = ({ planet }: { planet: PlanetConfig }) => {
       }}
       aria-hidden
     >
-      {/* Light theme */}
-      <div className='absolute inset-0 dark:hidden' style={{ width: planet.size, height: planet.size }}>
+      <div className='absolute inset-0' style={{ width: planet.size, height: planet.size }}>
         <div
           className='absolute inset-[-35%] rounded-full blur-2xl'
-          style={{ background: `radial-gradient(circle, ${planet.light.atmosphere} 0%, transparent 70%)` }}
+          style={{ background: `radial-gradient(circle, ${palette.atmosphere} 0%, transparent 70%)` }}
         />
-        {planet.hasRing && planet.light.ringStroke && (
-          <PlanetRing
-            size={planet.size}
-            stroke={planet.light.ringStroke}
-            fill={planet.light.ringFill ?? 'transparent'}
-          />
+        {planet.hasRing && palette.ringStroke && (
+          <PlanetRing size={planet.size} stroke={palette.ringStroke} fill={palette.ringFill ?? 'transparent'} />
         )}
         <div className='absolute left-0 top-0'>
-          <PlanetSphere size={planet.size} palette={planet.light} />
-        </div>
-      </div>
-
-      {/* Dark theme */}
-      <div className='absolute inset-0 hidden dark:block' style={{ width: planet.size, height: planet.size }}>
-        <div
-          className='absolute inset-[-35%] rounded-full blur-2xl'
-          style={{ background: `radial-gradient(circle, ${planet.dark.atmosphere} 0%, transparent 70%)` }}
-        />
-        {planet.hasRing && planet.dark.ringStroke && (
-          <PlanetRing size={planet.size} stroke={planet.dark.ringStroke} fill={planet.dark.ringFill ?? 'transparent'} />
-        )}
-        <div className='absolute left-0 top-0'>
-          <PlanetSphere size={planet.size} palette={planet.dark} />
+          <PlanetSphere size={planet.size} palette={palette} driftDuration={planet.driftDuration} />
         </div>
       </div>
     </motion.div>
@@ -248,27 +239,36 @@ const Planet = ({ planet }: { planet: PlanetConfig }) => {
 };
 
 export const SpaceBackground = () => {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = mounted ? resolvedTheme === 'dark' : false;
+
   return (
     <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden' aria-hidden>
-      <div className='absolute inset-x-0 bottom-0 h-[45vh] bg-gradient-to-t from-[#ff9a3c]/25 via-[#8a4a68]/15 to-transparent dark:hidden' />
+      <div className='absolute inset-x-0 bottom-0 h-[45vh] bg-gradient-to-t from-[#ff9a3c]/25 via-[#8a4a68]/[0.15] to-transparent dark:hidden' />
       <div className='absolute bottom-[-10%] left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[#ffc090]/30 blur-3xl dark:hidden' />
       <div className='absolute inset-0 hidden bg-gradient-to-b from-[#000010]/80 via-transparent to-[#000008]/60 dark:block' />
 
       <div className='absolute inset-0 opacity-60 dark:opacity-80'>
-        <span className='absolute left-[8%] top-[38%] h-5 w-80 rotate-[-12deg] rounded-full bg-gradient-to-r from-orange-200/20 via-white/10 to-rose-200/15 blur-2xl dark:from-blue-300/10 dark:via-white/8 dark:to-purple-300/10' />
-        <span className='absolute left-[30%] top-[48%] h-4 w-96 rotate-[8deg] rounded-full bg-gradient-to-r from-amber-200/15 via-white/8 to-fuchsia-200/12 blur-2xl dark:from-cyan-300/8 dark:via-white/6 dark:to-indigo-300/10' />
+        <span className='absolute left-[8%] top-[38%] h-5 w-80 rotate-[-12deg] rounded-full bg-gradient-to-r from-orange-200/20 via-white/10 to-rose-200/[0.15] blur-2xl dark:from-blue-300/10 dark:via-white/[0.08] dark:to-purple-300/10' />
+        <span className='absolute left-[30%] top-[48%] h-4 w-96 rotate-[8deg] rounded-full bg-gradient-to-r from-amber-200/[0.15] via-white/[0.08] to-fuchsia-200/[0.12] blur-2xl dark:from-cyan-300/[0.08] dark:via-white/[0.06] dark:to-indigo-300/10' />
       </div>
 
       {twilightStars}
       {darkStars}
 
-      <div className='absolute -left-32 top-[10%] h-96 w-96 rounded-full bg-[#8a4a68]/20 blur-3xl dark:bg-[#3de8ff]/6' />
-      <div className='absolute -right-24 top-[30%] h-72 w-72 rounded-full bg-[#ffc090]/15 blur-3xl dark:bg-[#6366f1]/8' />
+      <div className='absolute -left-32 top-[10%] h-96 w-96 rounded-full bg-[#8a4a68]/20 blur-3xl dark:bg-[#3de8ff]/[0.06]' />
+      <div className='absolute -right-24 top-[30%] h-72 w-72 rounded-full bg-[#ffc090]/[0.15] blur-3xl dark:bg-[#6366f1]/[0.08]' />
       <div className='absolute bottom-[20%] left-[20%] h-64 w-64 rounded-full bg-[#c878ff]/10 blur-3xl dark:hidden' />
       <div className='absolute right-[10%] top-[15%] hidden h-56 w-56 rounded-full bg-[#3de8ff]/5 blur-3xl dark:block' />
 
       {planets.map((planet) => (
-        <Planet key={planet.id} planet={planet} />
+        <Planet key={planet.id} planet={planet} isDark={isDark} />
       ))}
     </div>
   );

--- a/src/widgets/post/ui/blog-theme.ts
+++ b/src/widgets/post/ui/blog-theme.ts
@@ -15,9 +15,9 @@ export const blogTheme = {
   navBtn:
     'border border-[#ff9a3c]/25 bg-[#2a1545]/60 text-[#ffe8d0] hover:border-[#ff9a3c]/55 hover:bg-[#3d1f5c]/70 hover:shadow-[0_0_16px_rgba(255,154,60,0.15)] dark:border-[#3de8ff]/20 dark:bg-black/35 dark:text-[#c8e8ff] dark:hover:border-[#3de8ff]/45 dark:hover:bg-black/50 dark:hover:shadow-[0_0_16px_rgba(61,232,255,0.12)]',
   dropdown:
-    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-md dark:border-[#3de8ff]/15 dark:bg-[#070414]/95',
+    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-md dark:border-[#3de8ff]/[0.15] dark:bg-[#070414]/95',
   sidebar:
-    'border-l border-[#ff9a3c]/15 bg-[#1c0e38]/85 shadow-[-8px_0_32px_rgba(255,154,60,0.06)] backdrop-blur-md dark:border-[#3de8ff]/12 dark:bg-[#070414]/80 dark:shadow-[-8px_0_32px_rgba(61,232,255,0.05)]',
+    'border-l border-[#ff9a3c]/[0.15] bg-[#1c0e38]/85 shadow-[-8px_0_32px_rgba(255,154,60,0.06)] backdrop-blur-md dark:border-[#3de8ff]/[0.12] dark:bg-[#070414]/80 dark:shadow-[-8px_0_32px_rgba(61,232,255,0.05)]',
 
   /* ── Typography ── */
   titleGradient:
@@ -35,13 +35,13 @@ export const blogTheme = {
 
   /* ── Nav ── */
   navActive:
-    'border border-[#ff9a3c]/45 bg-[#ff9a3c]/10 text-[#ffc8a0] shadow-[0_0_12px_rgba(255,154,60,0.15)] dark:border-[#3de8ff]/40 dark:bg-[#3de8ff]/8 dark:text-[#3de8ff] dark:shadow-[0_0_12px_rgba(61,232,255,0.12)]',
+    'border border-[#ff9a3c]/45 bg-[#ff9a3c]/10 text-[#ffc8a0] shadow-[0_0_12px_rgba(255,154,60,0.15)] dark:border-[#3de8ff]/40 dark:bg-[#3de8ff]/[0.08] dark:text-[#3de8ff] dark:shadow-[0_0_12px_rgba(61,232,255,0.12)]',
   navIdle:
-    'border border-transparent text-[#ffe8d0]/85 hover:bg-[#ff9a3c]/8 dark:text-[#c8e8ff]/85 dark:hover:bg-[#3de8ff]/8',
+    'border border-transparent text-[#ffe8d0]/85 hover:bg-[#ff9a3c]/[0.08] dark:text-[#c8e8ff]/85 dark:hover:bg-[#3de8ff]/[0.08]',
 
   /* ── Cards ── */
   card:
-    'border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/90 via-[#1c0e38]/80 to-[#12082a]/90 shadow-[0_4px_24px_rgba(255,154,60,0.08)] backdrop-blur-sm dark:border-[#3de8ff]/15 dark:from-[#0a0618]/90 dark:via-[#070414]/85 dark:to-[#000008]/90 dark:shadow-[0_4px_24px_rgba(61,232,255,0.06)]',
+    'border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/90 via-[#1c0e38]/80 to-[#12082a]/90 shadow-[0_4px_24px_rgba(255,154,60,0.08)] backdrop-blur-sm dark:border-[#3de8ff]/[0.15] dark:from-[#0a0618]/90 dark:via-[#070414]/85 dark:to-[#000008]/90 dark:shadow-[0_4px_24px_rgba(61,232,255,0.06)]',
   cardTopGlow:
     'pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#ff9a3c]/70 to-transparent dark:via-[#3de8ff]/60',
   cardHover:
@@ -49,36 +49,36 @@ export const blogTheme = {
   categoryPill:
     'rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#ffc8a0] dark:border-[#3de8ff]/30 dark:bg-[#3de8ff]/10 dark:text-[#3de8ff]',
   listRow:
-    'group relative border border-transparent hover:border-[#ff9a3c]/20 hover:bg-[#ff9a3c]/5 dark:hover:border-[#3de8ff]/15 dark:hover:bg-[#3de8ff]/5',
+    'group relative border border-transparent hover:border-[#ff9a3c]/20 hover:bg-[#ff9a3c]/5 dark:hover:border-[#3de8ff]/[0.15] dark:hover:bg-[#3de8ff]/5',
   listAccent:
     'absolute left-0 top-4 bottom-4 w-0.5 rounded-full bg-gradient-to-b from-[#ff9a3c] to-transparent opacity-0 transition-opacity group-hover:opacity-100 dark:from-[#3de8ff]',
-  divider: 'border-[#ff9a3c]/12 dark:border-[#3de8ff]/10',
+  divider: 'border-[#ff9a3c]/[0.12] dark:border-[#3de8ff]/10',
 
   /* ── Misc ── */
   iconBtn: 'text-[#ffe8d0]/85 hover:bg-[#ff9a3c]/10 hover:text-[#ffc8a0] dark:text-[#c8e8ff]/85 dark:hover:bg-[#3de8ff]/10 dark:hover:text-white',
-  dropdownItem: 'text-[#ffe8d0] hover:bg-[#ff9a3c]/10 dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/8',
+  dropdownItem: 'text-[#ffe8d0] hover:bg-[#ff9a3c]/10 dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/[0.08]',
   overlay: 'bg-[#1a0f2e]/70 dark:bg-black/65',
   searchIcon:
-    'text-[#ffc8a0] hover:bg-[#ff9a3c]/15 hover:text-[#ffe8d0] dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/10 dark:hover:text-white',
+    'text-[#ffc8a0] hover:bg-[#ff9a3c]/[0.15] hover:text-[#ffe8d0] dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/10 dark:hover:text-white',
   searchPanel:
-    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-xl dark:border-[#3de8ff]/15 dark:bg-[#070414]/95',
+    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-xl dark:border-[#3de8ff]/[0.15] dark:bg-[#070414]/95',
   postSection:
-    'md:border md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.1)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
+    'md:border md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.1)] dark:md:border-[#3de8ff]/[0.15] dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
 
   /* ── Post detail / Comments ── */
   tagPill:
-    'rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-3 py-1 text-xs text-[#ffc8a0] dark:border-[#3de8ff]/25 dark:bg-[#3de8ff]/8 dark:text-[#3de8ff]',
+    'rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-3 py-1 text-xs text-[#ffc8a0] dark:border-[#3de8ff]/25 dark:bg-[#3de8ff]/[0.08] dark:text-[#3de8ff]',
   summaryBox:
-    'rounded-lg border border-[#ff9a3c]/25 bg-gradient-to-r from-[#ff9a3c]/8 to-[#8a4a68]/10 p-4 dark:border-[#3de8ff]/20 dark:from-[#3de8ff]/6 dark:to-[#6366f1]/8',
+    'rounded-lg border border-[#ff9a3c]/25 bg-gradient-to-r from-[#ff9a3c]/[0.08] to-[#8a4a68]/10 p-4 dark:border-[#3de8ff]/20 dark:from-[#3de8ff]/[0.06] dark:to-[#6366f1]/[0.08]',
   commentSection:
-    'relative mt-10 max-w-4xl rounded-2xl px-4 py-8 sm:px-6 md:border md:px-8 md:backdrop-blur-sm md:overflow-hidden md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.08)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
+    'relative mt-10 max-w-4xl rounded-2xl px-4 py-8 sm:px-6 md:border md:px-8 md:backdrop-blur-sm md:overflow-hidden md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.08)] dark:md:border-[#3de8ff]/[0.15] dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
   commentCard:
-    'relative rounded-xl border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/70 to-[#1c0e38]/60 p-4 dark:border-[#3de8ff]/15 dark:from-[#0a0618]/80 dark:to-[#070414]/60',
+    'relative rounded-xl border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/70 to-[#1c0e38]/60 p-4 dark:border-[#3de8ff]/[0.15] dark:from-[#0a0618]/80 dark:to-[#070414]/60',
   commentReplyCard:
-    'relative rounded-lg border border-[#ff9a3c]/15 bg-gradient-to-br from-[#2a1545]/50 to-[#1c0e38]/40 p-3 dark:border-[#3de8ff]/12 dark:from-[#070414]/70 dark:to-[#0a0618]/50',
+    'relative rounded-lg border border-[#ff9a3c]/[0.15] bg-gradient-to-br from-[#2a1545]/50 to-[#1c0e38]/40 p-3 dark:border-[#3de8ff]/[0.12] dark:from-[#070414]/70 dark:to-[#0a0618]/50',
   commentInput:
     'w-full resize-none rounded-lg border border-[#ff9a3c]/30 bg-[#2a1545]/80 p-3 font-mono text-[#ffe8d0] focus:outline-none focus:ring-2 focus:ring-[#ff9a3c]/40 dark:border-[#3de8ff]/25 dark:bg-[#070414]/80 dark:text-[#c8e8ff] dark:focus:ring-[#3de8ff]/35',
   commentLink:
     'text-xs text-[#ffb870] hover:text-[#ffc8a0] hover:underline dark:text-[#3de8ff] dark:hover:text-[#7ec8ff]',
-  commentReplyBorder: 'border-l-2 border-[#ff9a3c]/20 pl-4 dark:border-[#3de8ff]/15',
+  commentReplyBorder: 'border-l-2 border-[#ff9a3c]/20 pl-4 dark:border-[#3de8ff]/[0.15]',
 } as const;

--- a/src/widgets/post/ui/blog-theme.ts
+++ b/src/widgets/post/ui/blog-theme.ts
@@ -1,0 +1,84 @@
+/** 블로그 (posts) 테마 — light: 황혼(golden hour), dark: 심해(deep space) */
+export const blogTheme = {
+  /* ── Shell ── */
+  shell:
+    'bg-gradient-to-b from-[#2a1545] via-[#1c0e38] to-[#12082a] text-[#ffe8d0] dark:from-[#000008] dark:via-[#070414] dark:to-[#0a0618] dark:text-[#c8e8ff]',
+  shellRoot: 'min-h-screen bg-[#1a0f2e] dark:bg-[#000006]',
+  bottomVeil:
+    'bg-gradient-to-t from-[rgba(255,154,60,0.22)] via-[rgba(138,74,104,0.12)] to-transparent dark:from-[rgba(1,4,12,0.85)] dark:via-[rgba(2,6,14,0.4)] dark:to-transparent',
+
+  /* ── Chrome ── */
+  chromeBar:
+    'border border-[#ff9a3c]/25 bg-[#1c0e38]/80 shadow-[0_0_32px_rgba(255,154,60,0.12),inset_0_1px_0_rgba(255,200,160,0.15)] backdrop-blur-md dark:border-[#3de8ff]/20 dark:bg-black/40 dark:shadow-[0_0_32px_rgba(61,232,255,0.1),inset_0_1px_0_rgba(255,255,255,0.06)]',
+  chromeShine:
+    'pointer-events-none absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-[#ff9a3c]/50 to-transparent dark:via-[#3de8ff]/40',
+  navBtn:
+    'border border-[#ff9a3c]/25 bg-[#2a1545]/60 text-[#ffe8d0] hover:border-[#ff9a3c]/55 hover:bg-[#3d1f5c]/70 hover:shadow-[0_0_16px_rgba(255,154,60,0.15)] dark:border-[#3de8ff]/20 dark:bg-black/35 dark:text-[#c8e8ff] dark:hover:border-[#3de8ff]/45 dark:hover:bg-black/50 dark:hover:shadow-[0_0_16px_rgba(61,232,255,0.12)]',
+  dropdown:
+    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-md dark:border-[#3de8ff]/15 dark:bg-[#070414]/95',
+  sidebar:
+    'border-l border-[#ff9a3c]/15 bg-[#1c0e38]/85 shadow-[-8px_0_32px_rgba(255,154,60,0.06)] backdrop-blur-md dark:border-[#3de8ff]/12 dark:bg-[#070414]/80 dark:shadow-[-8px_0_32px_rgba(61,232,255,0.05)]',
+
+  /* ── Typography ── */
+  titleGradient:
+    'bg-gradient-to-r from-[#ffc8a0] via-[#ff9a3c] to-[#e878a0] bg-clip-text text-transparent dark:from-[#3de8ff] dark:via-[#7ec8ff] dark:to-[#818cf8]',
+  sectionTitle:
+    'text-sm font-semibold uppercase tracking-[0.2em] text-[#ff9a3c] dark:text-[#3de8ff]',
+  sectionLine:
+    'h-px flex-1 bg-gradient-to-r from-transparent to-[#ff9a3c]/50 dark:to-[#3de8ff]/40',
+  sectionLineReverse:
+    'h-px flex-1 bg-gradient-to-l from-transparent to-[#ff9a3c]/50 dark:to-[#3de8ff]/40',
+  labelAccent: 'text-[#ff9a3c] dark:text-[#3de8ff]',
+  textPrimary: 'text-[#ffe8d0] dark:text-[#c8e8ff]',
+  textMuted: 'text-[#d4a8c0]/85 dark:text-[#7ec8ff]/75',
+  textAccent: 'text-[#ffb870] dark:text-[#3de8ff]',
+
+  /* ── Nav ── */
+  navActive:
+    'border border-[#ff9a3c]/45 bg-[#ff9a3c]/10 text-[#ffc8a0] shadow-[0_0_12px_rgba(255,154,60,0.15)] dark:border-[#3de8ff]/40 dark:bg-[#3de8ff]/8 dark:text-[#3de8ff] dark:shadow-[0_0_12px_rgba(61,232,255,0.12)]',
+  navIdle:
+    'border border-transparent text-[#ffe8d0]/85 hover:bg-[#ff9a3c]/8 dark:text-[#c8e8ff]/85 dark:hover:bg-[#3de8ff]/8',
+
+  /* ── Cards ── */
+  card:
+    'border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/90 via-[#1c0e38]/80 to-[#12082a]/90 shadow-[0_4px_24px_rgba(255,154,60,0.08)] backdrop-blur-sm dark:border-[#3de8ff]/15 dark:from-[#0a0618]/90 dark:via-[#070414]/85 dark:to-[#000008]/90 dark:shadow-[0_4px_24px_rgba(61,232,255,0.06)]',
+  cardTopGlow:
+    'pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#ff9a3c]/70 to-transparent dark:via-[#3de8ff]/60',
+  cardHover:
+    'hover:border-[#ff9a3c]/45 hover:shadow-[0_0_28px_rgba(255,154,60,0.18)] dark:hover:border-[#3de8ff]/35 dark:hover:shadow-[0_0_28px_rgba(61,232,255,0.14)]',
+  categoryPill:
+    'rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#ffc8a0] dark:border-[#3de8ff]/30 dark:bg-[#3de8ff]/10 dark:text-[#3de8ff]',
+  listRow:
+    'group relative border border-transparent hover:border-[#ff9a3c]/20 hover:bg-[#ff9a3c]/5 dark:hover:border-[#3de8ff]/15 dark:hover:bg-[#3de8ff]/5',
+  listAccent:
+    'absolute left-0 top-4 bottom-4 w-0.5 rounded-full bg-gradient-to-b from-[#ff9a3c] to-transparent opacity-0 transition-opacity group-hover:opacity-100 dark:from-[#3de8ff]',
+  divider: 'border-[#ff9a3c]/12 dark:border-[#3de8ff]/10',
+
+  /* ── Misc ── */
+  iconBtn: 'text-[#ffe8d0]/85 hover:bg-[#ff9a3c]/10 hover:text-[#ffc8a0] dark:text-[#c8e8ff]/85 dark:hover:bg-[#3de8ff]/10 dark:hover:text-white',
+  dropdownItem: 'text-[#ffe8d0] hover:bg-[#ff9a3c]/10 dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/8',
+  overlay: 'bg-[#1a0f2e]/70 dark:bg-black/65',
+  searchIcon:
+    'text-[#ffc8a0] hover:bg-[#ff9a3c]/15 hover:text-[#ffe8d0] dark:text-[#c8e8ff] dark:hover:bg-[#3de8ff]/10 dark:hover:text-white',
+  searchPanel:
+    'border border-[#ff9a3c]/20 bg-[#1c0e38]/95 backdrop-blur-xl dark:border-[#3de8ff]/15 dark:bg-[#070414]/95',
+  postSection:
+    'md:border md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.1)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
+
+  /* ── Post detail / Comments ── */
+  tagPill:
+    'rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 px-3 py-1 text-xs text-[#ffc8a0] dark:border-[#3de8ff]/25 dark:bg-[#3de8ff]/8 dark:text-[#3de8ff]',
+  summaryBox:
+    'rounded-lg border border-[#ff9a3c]/25 bg-gradient-to-r from-[#ff9a3c]/8 to-[#8a4a68]/10 p-4 dark:border-[#3de8ff]/20 dark:from-[#3de8ff]/6 dark:to-[#6366f1]/8',
+  commentSection:
+    'relative mt-10 max-w-4xl rounded-2xl px-4 py-8 sm:px-6 md:border md:px-8 md:backdrop-blur-sm md:overflow-hidden mx-4 lg:mx-auto md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.08)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
+  commentCard:
+    'relative rounded-xl border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/70 to-[#1c0e38]/60 p-4 dark:border-[#3de8ff]/15 dark:from-[#0a0618]/80 dark:to-[#070414]/60',
+  commentReplyCard:
+    'relative rounded-lg border border-[#ff9a3c]/15 bg-gradient-to-br from-[#2a1545]/50 to-[#1c0e38]/40 p-3 dark:border-[#3de8ff]/12 dark:from-[#070414]/70 dark:to-[#0a0618]/50',
+  commentInput:
+    'w-full resize-none rounded-lg border border-[#ff9a3c]/30 bg-[#2a1545]/80 p-3 font-mono text-[#ffe8d0] focus:outline-none focus:ring-2 focus:ring-[#ff9a3c]/40 dark:border-[#3de8ff]/25 dark:bg-[#070414]/80 dark:text-[#c8e8ff] dark:focus:ring-[#3de8ff]/35',
+  commentLink:
+    'text-xs text-[#ffb870] hover:text-[#ffc8a0] hover:underline dark:text-[#3de8ff] dark:hover:text-[#7ec8ff]',
+  commentReplyBorder: 'border-l-2 border-[#ff9a3c]/20 pl-4 dark:border-[#3de8ff]/15',
+} as const;

--- a/src/widgets/post/ui/blog-theme.ts
+++ b/src/widgets/post/ui/blog-theme.ts
@@ -71,7 +71,7 @@ export const blogTheme = {
   summaryBox:
     'rounded-lg border border-[#ff9a3c]/25 bg-gradient-to-r from-[#ff9a3c]/8 to-[#8a4a68]/10 p-4 dark:border-[#3de8ff]/20 dark:from-[#3de8ff]/6 dark:to-[#6366f1]/8',
   commentSection:
-    'relative mt-10 max-w-4xl rounded-2xl px-4 py-8 sm:px-6 md:border md:px-8 md:backdrop-blur-sm md:overflow-hidden mx-4 lg:mx-auto md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.08)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
+    'relative mt-10 max-w-4xl rounded-2xl px-4 py-8 sm:px-6 md:border md:px-8 md:backdrop-blur-sm md:overflow-hidden md:border-[#ff9a3c]/20 md:bg-gradient-to-br md:from-[#2a1545]/90 md:via-[#1c0e38]/85 md:to-[#12082a]/80 md:shadow-[0_0_32px_rgba(255,154,60,0.08)] dark:md:border-[#3de8ff]/15 dark:md:from-[#0a0618]/90 dark:md:via-[#070414]/90 dark:md:to-[#000008]/85 dark:md:shadow-[0_0_32px_rgba(61,232,255,0.08)]',
   commentCard:
     'relative rounded-xl border border-[#ff9a3c]/20 bg-gradient-to-br from-[#2a1545]/70 to-[#1c0e38]/60 p-4 dark:border-[#3de8ff]/15 dark:from-[#0a0618]/80 dark:to-[#070414]/60',
   commentReplyCard:

--- a/src/widgets/post/ui/index.ts
+++ b/src/widgets/post/ui/index.ts
@@ -6,6 +6,8 @@ export { default as Sidebar } from './Sidebar';
 export { MobileNavbar } from './MobileNavbar';
 export { SpaceBackground } from './SpaceBackground';
 export { PostBackButton } from './PostBackButton';
+export { PostsLayoutShell } from './PostsLayoutShell';
+export { BlogSectionTitle } from './BlogSectionTitle';
 export { SearchBar } from './SearchBar';
 export { CategoryTree } from './CategoryTree';
 export * from './ComputerBackground/index';

--- a/src/widgets/post/ui/index.ts
+++ b/src/widgets/post/ui/index.ts
@@ -5,6 +5,7 @@ export { default as BlogHeader } from './BlogHeader';
 export { default as Sidebar } from './Sidebar';
 export { MobileNavbar } from './MobileNavbar';
 export { SpaceBackground } from './SpaceBackground';
+export { PostBackButton } from './PostBackButton';
 export { SearchBar } from './SearchBar';
 export { CategoryTree } from './CategoryTree';
 export * from './ComputerBackground/index';


### PR DESCRIPTION
## Summary
- `/blog/(posts)` 영역을 홈 코스모스와 맞춘 황혼(light)/심해(dark) 테마로 재구성
- 헤더·사이드바·카드·상세·댓글·본문(ProseMirror)까지 테마 토큰으로 통일
- 상세 페이지 `목록으로` 뒤로가기 추가, PostView 조회수 unique 충돌 및 fetcher 에러 메시지 수정

## Test plan
- [ ] `/blog/all`에서 라이트/다크 토글 시 배경·악센트·카드 hover 색이 구분되는지 확인
- [ ] 사이드바 Category/Tags, VisitorCounter, 행성 배경 표시 확인
- [ ] 포스트 상세 본문/댓글 텍스트 색이 테마에 따라 바뀌는지 확인
- [ ] 상세 `목록으로` 클릭 시 이전 페이지 또는 카테고리 목록으로 이동하는지 확인
- [ ] 같은 포스트를 연속 조회해도 500 없이 조회수가 정상 동작하는지 확인


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 블로그 게시물 상세 페이지에 카테고리 경로, 태그, 뒤로가기 버튼을 추가했습니다.
  * 게시물 레이아웃에 테마 기반 헤더, 사이드바, 섹션 제목과 반응형 구성을 적용했습니다.
  * 라이트·다크 모드에 맞춘 게시물, 댓글, 검색, 태그 및 에디터 스타일을 제공합니다.
  * 방문자 수 표시와 블로그 카드·배경 시각 효과를 개선했습니다.

* **버그 수정**
  * 존재하지 않거나 필수 정보가 누락된 게시물은 적절한 없음 페이지로 표시됩니다.
  * 게시물 조회수가 동일한 환경에서 24시간 내 중복 집계되지 않도록 개선했습니다.
  * API 오류 메시지가 더 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->