### PR TITLE
fix: 블로그 검색 필터·UX 개선

### DIFF
--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -13,7 +13,7 @@ import prisma from '@/shared/lib/db';
  *         name: search
  *         schema:
  *           type: string
- *         description: 게시물 검색어 (title, content)
+ *         description: 게시물 검색어 (title, content, tag name)
  *       - in: query
  *         name: category
  *         schema:
@@ -23,7 +23,7 @@ import prisma from '@/shared/lib/db';
  *         name: tags
  *         schema:
  *           type: string
- *         description: 태그 ID들을 쉼표로 구분하여 필터링
+ *         description: 태그 ID 또는 이름을 쉼표로 구분하여 필터링
  *       - in: query
  *         name: page
  *         schema:
@@ -116,11 +116,12 @@ export async function GET(req: NextRequest) {
 
     const whereClause: any = {};
 
-    // 검색어 필터링
+    // 검색어 필터링 (제목·본문·태그명)
     if (search) {
       whereClause.OR = [
         { title: { contains: search, mode: 'insensitive' } },
         { content: { contains: search, mode: 'insensitive' } },
+        { tags: { some: { name: { contains: search, mode: 'insensitive' } } } },
       ];
     }
 
@@ -131,18 +132,38 @@ export async function GET(req: NextRequest) {
       };
     }
 
-    // 태그 필터링
+    // 태그 필터링 (숫자 ID 또는 이름)
     if (tags) {
-      const tagIds = tags
+      const tagTokens = tags
         .split(',')
-        .map((id) => Number.parseInt(id.trim(), 10))
+        .map((token) => token.trim())
         .filter(Boolean);
-      if (tagIds.length > 0) {
-        whereClause.tags = {
-          some: {
-            id: { in: tagIds },
-          },
-        };
+
+      if (tagTokens.length > 0) {
+        const tagIds: number[] = [];
+        const tagNames: string[] = [];
+
+        for (const token of tagTokens) {
+          if (/^\d+$/.test(token)) {
+            tagIds.push(Number(token));
+          } else {
+            tagNames.push(token);
+          }
+        }
+
+        const tagConditions = [];
+        if (tagIds.length > 0) {
+          tagConditions.push({ id: { in: tagIds } });
+        }
+        if (tagNames.length > 0) {
+          tagConditions.push({ name: { in: tagNames, mode: 'insensitive' as const } });
+        }
+
+        if (tagConditions.length > 0) {
+          whereClause.tags = {
+            some: tagConditions.length === 1 ? tagConditions[0] : { OR: tagConditions },
+          };
+        }
       }
     }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,6 +18,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/blog/all`,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as const,
+      priority: 0.85,
+    },
+    {
       url: `${baseUrl}/portfolio`,
       lastModified: new Date(),
       changeFrequency: 'weekly' as const,
@@ -71,9 +77,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     });
 
-    // 태그 페이지 URL 생성
+    // 태그 검색 페이지 URL 생성 (/blog/all?tags=name)
     const tagPages = tags.map((tag) => ({
-      url: `${baseUrl}/blog/tags/${tag.name}`,
+      url: `${baseUrl}/blog/all?tags=${encodeURIComponent(tag.name)}`,
       lastModified: tag.createdAt || new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.5,

--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 # scripts/generate-types.sh
+set -euo pipefail
 
 ENV_FILE="$(pwd)/.env"
 if [ -f "$ENV_FILE" ]; then
-    source "$ENV_FILE"
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
 else
-    echo "Error: .env file not found in project root"
-    exit 1
+  echo "Error: .env file not found in project root"
+  exit 1
 fi
 
-openapi-typescript "$API_DOCS_URL" -o src/shared/api/openapi-types.ts
+if [ -z "${API_DOCS_URL:-}" ]; then
+  echo "Error: API_DOCS_URL is not set in .env"
+  exit 1
+fi
+
+OUT_FILE="src/shared/api/openapi-types.ts"
+
+# TypeScript 7 + openapi-typescript(현재) 조합이 깨져서,
+# 생성 시에는 typescript@5.8을 같이 올려 실행한다.
+pnpm dlx --package typescript@5.8.3 --package openapi-typescript@7.8.0 \
+  openapi-typescript "$API_DOCS_URL" -o "$OUT_FILE"
+
+echo "Generated $OUT_FILE from $API_DOCS_URL"

--- a/src/shared/api/openapi-types.ts
+++ b/src/shared/api/openapi-types.ts
@@ -1270,11 +1270,11 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description 게시물 검색어 (title, content) */
+                    /** @description 게시물 검색어 (title, content, tag name) */
                     search?: string;
                     /** @description 카테고리 slug로 필터링 */
                     category?: string;
-                    /** @description 태그 ID들을 쉼표로 구분하여 필터링 */
+                    /** @description 태그 ID 또는 이름을 쉼표로 구분하여 필터링 */
                     tags?: string;
                     /** @description 페이지 번호 */
                     page?: number;
@@ -2197,7 +2197,7 @@ export interface paths {
         };
         put?: never;
         /**
-         * 방문자 기록 추가
+         * 오늘 순방문자 카운트 (+1, 브라우저당 1회)
          * @description visitorId 클레임과 visitor_day 쿠키로 당일 중복을 원자적으로 막고 VisitorDaily.count만 증가시킵니다.
          */
         post: {
@@ -2210,8 +2210,9 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
+                        /** Format: uuid */
                         visitorId: string;
-                        /** 하위 호환용(저장하지 않음) */
+                        /** @description 하위 호환용(저장하지 않음) */
                         path?: string;
                     };
                 };

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { usePost } from '@/features/post/model';
 import { useSearchParams } from 'next/navigation';
 import { RecentPosts } from './RecentPosts';
@@ -9,23 +10,24 @@ import { BlogSectionTitle } from './BlogSectionTitle';
 export const BlogMainPage = () => {
   const searchParams = useSearchParams();
   const search = searchParams.get('search');
+  const category = searchParams.get('category');
+  const tagsParam = searchParams.get('tags');
+  const tags = tagsParam?.split(',').filter(Boolean) ?? [];
+  const hasFilters = Boolean(search || category || tags.length > 0);
+
   const { posts, isLoading } = usePost({
     search: search ?? '',
-    category: searchParams.get('category') ?? '',
-    tags: searchParams.get('tags') ?? '',
+    category: category ?? '',
+    tags: tagsParam ?? '',
     page: 1,
     limit: 10,
   });
 
   const postsData = posts?.pages?.flatMap((page) => page.data ?? []) ?? [];
 
-  // 로딩 중이 아니고 결과가 없을 때
   if (!isLoading && postsData.length === 0) {
-    const category = searchParams.get('category');
-    const tags = searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
-
     return (
-      <div className='max-w-4xl mx-auto w-full'>
+      <div className='mx-auto w-full max-w-4xl'>
         <NoResults
           searchTerm={search ?? undefined}
           category={category ?? undefined}
@@ -35,11 +37,28 @@ export const BlogMainPage = () => {
     );
   }
 
+  if (hasFilters) {
+    const filterLabel = [
+      search ? `"${search}"` : null,
+      category ? `카테고리 ${category}` : null,
+      tags.length > 0 ? `태그 ${tags.map((tag) => `#${tag}`).join(' ')}` : null,
+    ]
+      .filter(Boolean)
+      .join(' · ');
+
+    return (
+      <div className='mx-auto w-full max-w-4xl'>
+        <BlogSectionTitle subtitle={filterLabel || '조건에 맞는 글'}>검색 결과</BlogSectionTitle>
+        <PostList posts={postsData} isLoading={isLoading} />
+      </div>
+    );
+  }
+
   const recentPosts = postsData.slice(0, 6);
   const restPosts = postsData.slice(6);
 
   return (
-    <div className='max-w-4xl mx-auto w-full'>
+    <div className='mx-auto w-full max-w-4xl'>
       <BlogSectionTitle subtitle='최근에 올라온 글'>Recent</BlogSectionTitle>
       <RecentPosts posts={recentPosts} isLoading={isLoading} />
 

--- a/src/widgets/post/ui/BlogSearch.tsx
+++ b/src/widgets/post/ui/BlogSearch.tsx
@@ -73,7 +73,7 @@ export function BlogSearch() {
     setSearchExpanded(!searchExpanded);
     if (!searchExpanded) {
       setTimeout(() => {
-        const searchInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+        const searchInput = document.querySelector('input[type="search"]') as HTMLInputElement;
         searchInput?.focus();
       }, 150);
     }
@@ -82,8 +82,8 @@ export function BlogSearch() {
   const shouldShowSearch = pathname === '/blog/all';
 
   const searchBarPlaceholder = useMemo(() => {
-    if (pills.length > 0) return 'Add to search...';
-    return 'Search posts, tags, or categories...';
+    if (pills.length > 0) return '검색어 추가...';
+    return '제목·본문·태그 검색...';
   }, [pills.length]);
 
   if (!shouldShowSearch) {
@@ -120,6 +120,8 @@ export function BlogSearch() {
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
                 className={`rounded-full p-1 transition-all duration-200 ${blogTheme.searchIcon}`}
+                aria-label='검색 필터'
+                aria-expanded={filterOpen}
               >
                 <Filter size={16} />
               </motion.button>
@@ -154,6 +156,7 @@ export function BlogSearch() {
               whileTap={{ scale: 0.9 }}
               transition={{ duration: 0.2 }}
               className={`rounded-full p-2 transition-all duration-300 ${blogTheme.searchIcon}`}
+              aria-label='검색 열기'
             >
               <Search size={18} />
             </motion.button>

--- a/src/widgets/post/ui/NoResults.tsx
+++ b/src/widgets/post/ui/NoResults.tsx
@@ -13,7 +13,14 @@ interface NoResultsProps {
 
 export const NoResults = ({ searchTerm, category, tags }: NoResultsProps) => {
   const router = useRouter();
-  const hasFilters = searchTerm || category || (tags && tags.length > 0);
+  const hasFilters = Boolean(searchTerm || category || (tags && tags.length > 0));
+  const filterLabel = [
+    searchTerm ? `"${searchTerm}"` : null,
+    category ? `카테고리: ${category}` : null,
+    tags?.length ? `태그: ${tags.map((tag) => `#${tag}`).join(' ')}` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <motion.div
@@ -29,11 +36,17 @@ export const NoResults = ({ searchTerm, category, tags }: NoResultsProps) => {
       </div>
 
       <h2
-        className={`mb-6 text-center text-xl font-semibold ${blogTheme.textPrimary}`}
+        className={`mb-2 text-center text-xl font-semibold ${blogTheme.textPrimary}`}
         style={{ fontFamily: 'var(--font-syne), sans-serif' }}
       >
         {hasFilters ? '검색 결과가 없습니다' : '아직 게시물이 없습니다'}
       </h2>
+
+      {hasFilters && filterLabel ? (
+        <p className={`mb-6 text-center text-sm ${blogTheme.textMuted}`}>{filterLabel}</p>
+      ) : (
+        <div className='mb-6' />
+      )}
 
       <button
         type='button'

--- a/src/widgets/post/ui/SearchBar.tsx
+++ b/src/widgets/post/ui/SearchBar.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { X } from 'lucide-react';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 export interface SearchPill {
   type: 'tag' | 'category';
@@ -13,7 +14,7 @@ export const SearchBar = ({
   pills,
   onTextChange,
   onPillRemove,
-  placeholder = 'Search posts...',
+  placeholder = '글 검색...',
 }: {
   text: string;
   pills: SearchPill[];
@@ -25,10 +26,12 @@ export const SearchBar = ({
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      transition={{ duration: 0.5, ease: 'easeOut' }}
-      className='w-full flex items-center ml-auto'
+      transition={{ duration: 0.35, ease: 'easeOut' }}
+      className='ml-auto flex w-full items-center'
     >
-      <div className='w-full flex items-center flex-wrap gap-2 px-4 py-2 rounded-lg bg-[#232946]/80 border border-blue-300/50 focus-within:border-blue-400 focus-within:shadow-[0_0_20px_#7dd3fc55] transition-all duration-300'>
+      <div
+        className={`flex w-full flex-wrap items-center gap-2 rounded-lg border px-3 py-2 transition-all duration-300 focus-within:border-[#ff9a3c]/55 focus-within:shadow-[0_0_18px_rgba(255,154,60,0.15)] dark:focus-within:border-[#3de8ff]/45 dark:focus-within:shadow-[0_0_18px_rgba(61,232,255,0.12)] ${blogTheme.card}`}
+      >
         {pills.map((pill) => (
           <motion.div
             key={`${pill.type}-${pill.value}`}
@@ -36,29 +39,30 @@ export const SearchBar = ({
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.5 }}
             transition={{ duration: 0.2 }}
-            className={`flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-sm font-medium ${
+            className={
               pill.type === 'tag'
-                ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-400/30'
-                : 'bg-blue-500/20 text-blue-300 border border-blue-400/30'
-            }`}
+                ? 'flex items-center gap-1 rounded-full border border-[#ff9a3c]/30 bg-[#ff9a3c]/10 py-0.5 pl-2 pr-1 text-sm font-medium text-[#ffc8a0] dark:border-[#3de8ff]/30 dark:bg-[#3de8ff]/10 dark:text-[#3de8ff]'
+                : 'flex items-center gap-1 rounded-full border border-[#e878a0]/30 bg-[#e878a0]/10 py-0.5 pl-2 pr-1 text-sm font-medium text-[#ffc8a0] dark:border-[#818cf8]/30 dark:bg-[#818cf8]/10 dark:text-[#a5b4fc]'
+            }
           >
-            <span>{pill.value}</span>
+            <span>{pill.type === 'tag' ? `#${pill.value}` : pill.value}</span>
             <button
               type='button'
               onClick={() => onPillRemove(pill)}
-              className='p-0.5 rounded-full hover:bg-white/20 transition-colors'
-              aria-label={`Remove ${pill.value}`}
+              className='rounded-full p-0.5 transition-colors hover:bg-white/20'
+              aria-label={`${pill.value} 필터 제거`}
             >
               <X size={12} />
             </button>
           </motion.div>
         ))}
         <input
-          type='text'
+          type='search'
           value={text}
           onChange={(e) => onTextChange(e.target.value)}
-          placeholder={pills.length === 0 ? placeholder : ''}
-          className='flex-1 min-w-[100px] bg-transparent focus:outline-none text-slate-100 placeholder:text-blue-200'
+          placeholder={pills.length === 0 ? placeholder : '검색어 추가...'}
+          aria-label='게시물 검색'
+          className={`min-w-[100px] flex-1 bg-transparent text-sm focus:outline-none ${blogTheme.textPrimary} placeholder:text-[#d4a8c0]/55 dark:placeholder:text-[#7ec8ff]/45`}
         />
       </div>
     </motion.div>

--- a/src/widgets/post/ui/SearchFilter.tsx
+++ b/src/widgets/post/ui/SearchFilter.tsx
@@ -7,6 +7,7 @@ import { Loader2, Tag as TagIcon, Folder, Inbox } from 'lucide-react';
 import { Tag } from '@/shared/ui/Tag';
 import { createPortal } from 'react-dom';
 import { useEffect, useState } from 'react';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import type { SearchPill } from './SearchBar';
 
 interface SearchFilterProps {
@@ -34,7 +35,7 @@ export const SearchFilter = ({ onSelect, existingPills, triggerRef }: SearchFilt
     if (triggerRef?.current) {
       const rect = triggerRef.current.getBoundingClientRect();
       setPosition({
-        top: rect.bottom + 20,
+        top: rect.bottom + 12,
         right: window.innerWidth - rect.right,
       });
     }
@@ -48,30 +49,32 @@ export const SearchFilter = ({ onSelect, existingPills, triggerRef }: SearchFilt
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: -10, scale: 0.95 }}
       transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-      className='w-80 bg-gray-900/95 backdrop-blur-xl border border-blue-400/30 rounded-xl shadow-2xl fixed z-[9999]'
+      className={`fixed z-[9999] w-80 rounded-xl p-1 shadow-2xl ${blogTheme.searchPanel}`}
       style={{
         top: `${position.top}px`,
         right: `${position.right}px`,
       }}
       onClick={(e) => e.stopPropagation()}
+      role='dialog'
+      aria-label='검색 필터'
     >
       <div className='p-3'>
-        <h2 className='text-sm font-bold text-blue-100 mb-3 px-1'>Filter by</h2>
+        <h2 className={`mb-3 px-1 text-sm font-bold ${blogTheme.sectionTitle}`}>필터</h2>
         {isLoading ? (
-          <div className='flex justify-center items-center p-4'>
-            <Loader2 className='animate-spin text-blue-300' size={20} />
+          <div className='flex items-center justify-center p-4'>
+            <Loader2 className={`animate-spin ${blogTheme.textAccent}`} size={20} />
           </div>
         ) : noResults ? (
-          <div className='text-center py-4 px-2'>
-            <Inbox size={24} className='mx-auto text-gray-500' />
-            <p className='mt-1 text-xs text-gray-400'>No categories or tags found.</p>
+          <div className='px-2 py-4 text-center'>
+            <Inbox size={24} className={`mx-auto ${blogTheme.textMuted}`} />
+            <p className={`mt-1 text-xs ${blogTheme.textMuted}`}>카테고리·태그가 없습니다</p>
           </div>
         ) : (
           <div className='space-y-4'>
             {categories && categories.length > 0 && (
               <div>
-                <h3 className='text-xs font-semibold text-blue-200 px-1 mb-2 flex items-center gap-1.5'>
-                  <Folder size={14} /> Categories
+                <h3 className={`mb-2 flex items-center gap-1.5 px-1 text-xs font-semibold ${blogTheme.textMuted}`}>
+                  <Folder size={14} /> 카테고리
                 </h3>
                 <div className='flex flex-wrap gap-1.5'>
                   {categories.map((category) => (
@@ -87,19 +90,19 @@ export const SearchFilter = ({ onSelect, existingPills, triggerRef }: SearchFilt
                     >
                       <Tag
                         size='sm'
-                        color='blue'
+                        color='orange'
                         type='glass'
                         hover={true}
-                        className={`cursor-pointer transition-all duration-200 ${
+                        className={`mb-0 cursor-pointer transition-all duration-200 ${
                           isPillSelected({ type: 'category', value: category.name })
-                            ? 'opacity-40 cursor-not-allowed'
-                            : 'hover:bg-blue-500/20'
+                            ? 'cursor-not-allowed opacity-40'
+                            : ''
                         }`}
                       >
                         {category.name}
-                        {category._count?.posts && (
+                        {category._count?.posts ? (
                           <span className='ml-1 text-xs opacity-70'>({category._count.posts})</span>
-                        )}
+                        ) : null}
                       </Tag>
                     </motion.div>
                   ))}
@@ -107,43 +110,45 @@ export const SearchFilter = ({ onSelect, existingPills, triggerRef }: SearchFilt
               </div>
             )}
 
-            {/* 구분선 */}
             {categories && categories.length > 0 && tags && tags.length > 0 && (
-              <div className='border-t border-gray-600/50 my-3' />
+              <div className={`my-3 border-t ${blogTheme.divider}`} />
             )}
 
             {tags && tags.length > 0 && (
               <div>
-                <h3 className='text-xs font-semibold text-yellow-200 px-1 mb-2 flex items-center gap-1.5'>
-                  <TagIcon size={14} /> Tags
+                <h3 className={`mb-2 flex items-center gap-1.5 px-1 text-xs font-semibold ${blogTheme.textMuted}`}>
+                  <TagIcon size={14} /> 태그
                 </h3>
                 <div className='flex flex-wrap gap-1.5'>
-                  {tags.map((tag) => (
-                    <motion.div
-                      key={tag.id}
-                      whileHover={{ scale: 1.05 }}
-                      whileTap={{ scale: 0.95 }}
-                      onClick={() => {
-                        if (!isPillSelected({ type: 'tag', value: tag.name ?? '' })) {
-                          onSelect({ type: 'tag', value: tag.name ?? '' });
-                        }
-                      }}
-                    >
-                      <Tag
-                        size='sm'
-                        color='yellow'
-                        type='glass'
-                        hover={true}
-                        className={`cursor-pointer transition-all duration-200 ${
-                          isPillSelected({ type: 'tag', value: tag.name ?? '' })
-                            ? 'opacity-40 cursor-not-allowed'
-                            : 'hover:bg-yellow-500/20'
-                        }`}
+                  {tags.map((tag) => {
+                    if (tag.id == null || !tag.name) return null;
+                    return (
+                      <motion.div
+                        key={tag.id}
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        onClick={() => {
+                          if (!isPillSelected({ type: 'tag', value: tag.name ?? '' })) {
+                            onSelect({ type: 'tag', value: tag.name ?? '' });
+                          }
+                        }}
                       >
-                        #{tag.name}
-                      </Tag>
-                    </motion.div>
-                  ))}
+                        <Tag
+                          size='sm'
+                          color='amber'
+                          type='glass'
+                          hover={true}
+                          className={`mb-0 cursor-pointer transition-all duration-200 ${
+                            isPillSelected({ type: 'tag', value: tag.name ?? '' })
+                              ? 'cursor-not-allowed opacity-40'
+                              : ''
+                          }`}
+                        >
+                          #{tag.name}
+                        </Tag>
+                      </motion.div>
+                    );
+                  })}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- 태그 필터가 URL의 태그 이름과 API ID 불일치로 실패하던 문제를 수정
- 제목·본문·태그명 검색과 필터 결과 뷰를 추가
- 검색 UI 코스모스 톤 정리, sitemap 태그 URL 및 openapi 타입 생성 스크립트 보완

## Test plan
- [ ] `/blog/all`에서 제목/본문 검색 확인
- [ ] 필터로 태그·카테고리 선택 시 결과 갱신 확인
- [ ] 결과 없음 상태와 필터 라벨 확인
- [ ] `pnpm run generate-types` 정상 실행 확인


Made with [Cursor](https://cursor.com)