### PR TITLE
feat: 블로그 SEO·RSS·OG 강화

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/opengraph-image.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from 'next/og';
+import prisma from '@/shared/lib/db';
+
+export const alt = '3D Blog Post';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+type Props = {
+  params: Promise<{ slug: string; postSlug: string }>;
+};
+
+export default async function PostOpenGraphImage({ params }: Props) {
+  const { postSlug } = await params;
+  const decodedSlug = decodeURIComponent(postSlug);
+
+  const post = await prisma.post.findUnique({
+    where: { slug: decodedSlug },
+    select: {
+      title: true,
+      category: { select: { name: true } },
+    },
+  });
+
+  const title = post?.title ?? '3D Blog';
+  const category = post?.category?.name ?? 'Article';
+  const displayTitle = title.length > 80 ? `${title.slice(0, 77)}...` : title;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 64,
+          background: 'linear-gradient(145deg, #2a1545 0%, #1c0e38 45%, #12082a 100%)',
+          color: '#ffe8d0',
+        }}
+      >
+        <div style={{ display: 'flex', fontSize: 24, letterSpacing: 4, color: '#ff9a3c', textTransform: 'uppercase' }}>
+          {category}
+        </div>
+        <div style={{ display: 'flex', fontSize: 60, fontWeight: 700, lineHeight: 1.15, maxWidth: 1000 }}>
+          {displayTitle}
+        </div>
+        <div style={{ display: 'flex', fontSize: 24, color: '#ffc8a0' }}>3D Blog</div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -7,22 +7,10 @@ import type { Metadata } from 'next';
 import type { PostResponse } from '@/entities/post/model/post';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
+import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
 import { notFound } from 'next/navigation';
 
 const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'));
-
-// HTML 태그 제거 및 description 추출 함수
-const extractDescription = (content: string, maxLength = 160) => {
-  const plainText = content
-    .replace(/<[^>]*>/g, '') // HTML 태그 제거
-    .replace(/\s+/g, ' ') // 연속 공백을 단일 공백으로
-    .trim();
-
-  if (plainText.length <= maxLength) {
-    return plainText;
-  }
-  return `${plainText.substring(0, maxLength).replace(/\s+\S*$/, '')}...`;
-};
 
 export async function generateMetadata({ params }: { params: Promise<{ postSlug: string }> }): Promise<Metadata> {
   const { postSlug } = await params;
@@ -31,75 +19,72 @@ export async function generateMetadata({ params }: { params: Promise<{ postSlug:
   try {
     const post = await getPostBySlug(decodedSlug);
     const description = extractDescription(post.content ?? '');
-  const publishedDate = post.createdAt ? new Date(post.createdAt).toISOString() : '';
-  const modifiedDate = post.updatedAt ? new Date(post.updatedAt).toISOString() : publishedDate;
-  const postUrl = `${process.env.NEXT_PUBLIC_APP_URL}/blog/category/${post.category?.slug || 'uncategorized'}/post/${postSlug}`;
-  const imageUrl = '/logo.png';
+    const publishedDate = post.createdAt ? new Date(post.createdAt).toISOString() : undefined;
+    const modifiedDate = post.updatedAt ? new Date(post.updatedAt).toISOString() : publishedDate;
+    const postUrl = getPostUrl(post.category?.slug, postSlug);
+    const keywords =
+      post.tags
+        ?.map((tag) => tag.name)
+        .filter((name): name is string => Boolean(name))
+        .join(', ') || undefined;
 
-  return {
-    title: post.title,
-    description,
-    keywords: post.tags?.map((tag) => tag.name).join(', ') || '',
-    authors: post.author?.name ? [{ name: post.author.name }] : [],
-    openGraph: {
+    return {
       title: post.title,
       description,
-      type: 'article',
-      publishedTime: publishedDate,
-      modifiedTime: modifiedDate,
-      authors: post.author?.name ? [post.author.name] : [],
-      tags: post.tags?.map((tag) => tag.name).filter((name): name is string => name !== undefined) || [],
-      images: [
-        {
-          url: imageUrl, // 기본 이미지 또는 포스트 대표 이미지
-          width: 1200,
-          height: 630,
-          alt: post.title,
-        },
-      ],
-      siteName: '3D Blog',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: post.title,
-      description,
-      images: ['/logo.png'], // 기본 이미지 또는 포스트 대표 이미지
-      creator: post.author?.name || '@3dblog',
-    },
-    robots: {
-      index: true,
-      follow: true,
-      googleBot: {
+      keywords,
+      authors: post.author?.name ? [{ name: post.author.name }] : [],
+      openGraph: {
+        title: post.title ?? undefined,
+        description,
+        type: 'article',
+        url: postUrl,
+        publishedTime: publishedDate,
+        modifiedTime: modifiedDate,
+        authors: post.author?.name ? [post.author.name] : [],
+        tags: post.tags?.map((tag) => tag.name).filter((name): name is string => Boolean(name)) || [],
+        siteName: '3D Blog',
+        locale: 'ko_KR',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: post.title ?? undefined,
+        description,
+        creator: post.author?.name || '@3dblog',
+      },
+      robots: {
         index: true,
         follow: true,
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
       },
-    },
-    alternates: {
-      canonical: postUrl,
-    },
-  };
+      alternates: {
+        canonical: postUrl,
+      },
+    };
   } catch {
     return {
-      title: 'Post not found',
+      title: '포스트를 찾을 수 없습니다',
     };
   }
 }
 
-// JSON-LD 구조화 데이터 컴포넌트
-const PostStructuredData = ({
-  post,
-}: {
-  post: PostResponse;
-}) => {
+const PostStructuredData = ({ post }: { post: PostResponse }) => {
+  const postUrl = getPostUrl(post.category?.slug, post.slug ?? '');
+  const imageUrl = toAbsoluteUrl(
+    `/blog/category/${post.category?.slug || 'uncategorized'}/post/${encodeURIComponent(post.slug ?? '')}/opengraph-image`,
+  );
+
   const jsonLd = {
     '@context': 'https://schema.org',
-    '@type': 'Article',
+    '@type': 'BlogPosting',
     headline: post.title,
     description: extractDescription(post.content ?? ''),
-    image: '/logo.png', // 기본 이미지 또는 포스트 대표 이미지
+    image: [imageUrl],
     author: {
       '@type': 'Person',
       name: post.author?.name || 'Unknown Author',
@@ -109,15 +94,16 @@ const PostStructuredData = ({
       name: '3D Blog',
       logo: {
         '@type': 'ImageObject',
-        url: '/logo.png',
+        url: toAbsoluteUrl('/opengraph-image'),
       },
     },
-    datePublished: post.createdAt ? new Date(post.createdAt).toISOString() : '',
-    dateModified: post.updatedAt ? new Date(post.updatedAt).toISOString() : '',
+    datePublished: post.createdAt ? new Date(post.createdAt).toISOString() : undefined,
+    dateModified: post.updatedAt ? new Date(post.updatedAt).toISOString() : undefined,
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': `/blog/category/${post.category?.slug || 'uncategorized'}/post/${post.slug}`,
+      '@id': postUrl,
     },
+    url: postUrl,
     ...(post.tags &&
       post.tags.length > 0 && {
         keywords: post.tags.map((tag) => tag.name).join(', '),
@@ -155,13 +141,11 @@ export default async function PostPage({
 
   return (
     <>
-      {/* SEO를 위한 구조화 데이터 */}
       <PostStructuredData post={post} />
 
       <div className='mx-4 max-w-4xl lg:mx-auto'>
         <PostBackButton href={backHref} />
 
-        {/* 본문 영역 꾸밈 */}
         <section
           className={`relative mb-12 mt-0 px-4 py-8 sm:px-6 md:rounded-2xl md:px-8 md:overflow-hidden ${blogTheme.postSection}`}
         >
@@ -195,7 +179,6 @@ export default async function PostPage({
             </div>
           )}
 
-          {/* AI 요약 표시 */}
           <div className='relative z-10 p-2'>
             <PostSummary
               post={{

--- a/app/(public)/blog/layout.tsx
+++ b/app/(public)/blog/layout.tsx
@@ -1,8 +1,21 @@
 import type { Metadata } from 'next';
+import { baseUrl } from '@/shared/consts/baseUrl';
 
 export const metadata: Metadata = {
   title: 'Blog',
-  description: 'Blog',
+  description: '웹 개발 기록, Next.js·Three.js 실험과 학습 노트.',
+  alternates: {
+    canonical: `${baseUrl}/blog`,
+    types: {
+      'application/rss+xml': `${baseUrl}/feed.xml`,
+    },
+  },
+  openGraph: {
+    title: 'Blog | 3D Blog',
+    description: '웹 개발 기록, Next.js·Three.js 실험과 학습 노트.',
+    url: `${baseUrl}/blog`,
+    type: 'website',
+  },
 };
 
 export default function BlogLayout({

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,5 +1,5 @@
-import prisma from '@/shared/lib/db';
 import { baseUrl, extractDescription, getPostUrl } from '@/shared/consts/baseUrl';
+import prisma from '@/shared/lib/db';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 3600;

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -30,7 +30,7 @@ export async function GET() {
 
   const items = posts
     .map((post) => {
-      const link = getPostUrl(post.category?.slug, post.slug);
+      const link = `${getPostUrl(post.category?.slug, post.slug)}?utm_source=rss&utm_medium=feed`;
       const description = extractDescription(post.content ?? '');
       const pubDate = (post.createdAt ?? new Date()).toUTCString();
       const categories = [

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,75 @@
+import prisma from '@/shared/lib/db';
+import { baseUrl, extractDescription, getPostUrl } from '@/shared/consts/baseUrl';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 3600;
+
+const escapeXml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+
+export async function GET() {
+  const posts = await prisma.post.findMany({
+    take: 50,
+    orderBy: { createdAt: 'desc' },
+    select: {
+      title: true,
+      slug: true,
+      content: true,
+      createdAt: true,
+      updatedAt: true,
+      category: { select: { slug: true, name: true } },
+      author: { select: { name: true } },
+      tags: { select: { name: true } },
+    },
+  });
+
+  const items = posts
+    .map((post) => {
+      const link = getPostUrl(post.category?.slug, post.slug);
+      const description = extractDescription(post.content ?? '');
+      const pubDate = (post.createdAt ?? new Date()).toUTCString();
+      const categories = [
+        post.category?.name ? `<category>${escapeXml(post.category.name)}</category>` : '',
+        ...(post.tags ?? []).map((tag) => `<category>${escapeXml(tag.name)}</category>`),
+      ]
+        .filter(Boolean)
+        .join('');
+
+      return `
+    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="true">${escapeXml(link)}</guid>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${pubDate}</pubDate>
+      ${post.author?.name ? `<dc:creator>${escapeXml(post.author.name)}</dc:creator>` : ''}
+      ${categories}
+    </item>`;
+    })
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>3D Blog</title>
+    <link>${escapeXml(baseUrl)}</link>
+    <description>웹 개발 기록과 Three.js 기반 3D 홈·포트폴리오</description>
+    <language>ko</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${escapeXml(`${baseUrl}/feed.xml`)}" rel="self" type="application/rss+xml" />
+    ${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,6 +39,9 @@ export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   alternates: {
     canonical: '/',
+    types: {
+      'application/rss+xml': `${baseUrl}/feed.xml`,
+    },
   },
   openGraph: {
     type: 'website',
@@ -47,28 +50,11 @@ export const metadata: Metadata = {
     title: '3D Blog',
     description: '웹 개발 기록과 Three.js로 만든 3D 홈·포트폴리오.',
     siteName: '3D Blog',
-    images: [
-      {
-        url: '/logo.png',
-        width: 1200,
-        height: 630,
-        alt: '3D Blog 로고',
-        type: 'image/png',
-      },
-      {
-        url: '/logo.png',
-        width: 800,
-        height: 800,
-        alt: '3D Blog 로고',
-        type: 'image/png',
-      },
-    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: '3D Blog',
     description: '웹 개발 기록과 Three.js로 만든 3D 홈·포트폴리오.',
-    images: ['/logo.png', '/logo-square.png'],
   },
   robots: {
     index: true,

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,35 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt = '3D Blog';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 64,
+          background: 'linear-gradient(145deg, #2a1545 0%, #1c0e38 45%, #12082a 100%)',
+          color: '#ffe8d0',
+        }}
+      >
+        <div style={{ display: 'flex', fontSize: 28, letterSpacing: 6, color: '#ff9a3c', textTransform: 'uppercase' }}>
+          3D TECH BLOG
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ fontSize: 72, fontWeight: 700, lineHeight: 1.1 }}>웹 개발 기록과 3D 실험</div>
+          <div style={{ fontSize: 28, color: '#d4a8c0' }}>Next.js · Three.js · React Three Fiber</div>
+        </div>
+        <div style={{ display: 'flex', fontSize: 24, color: '#ffc8a0' }}>3D Blog</div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,19 +6,11 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: ['/', '/blog', '/blog/category/*', '/blog/category/*/post/*', '/blog/tags/*', '/portfolio'],
-        disallow: [
-          '/admin/*',
-          '/api/*',
-          '/login',
-          '/sign-up',
-          '/(protect)/*',
-          '/swagger/*',
-          '/_next/*',
-          '/favicon.ico',
-        ],
+        allow: ['/', '/blog', '/blog/all', '/blog/category/*', '/blog/category/*/post/*', '/portfolio', '/feed.xml'],
+        disallow: ['/admin', '/admin/*', '/api/*', '/login', '/sign-up', '/swagger', '/swagger/*'],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,30 +3,40 @@ import prisma from '@/shared/lib/db';
 import { baseUrl } from '@/shared/consts/baseUrl';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // 정적 페이지들
-  const staticPages = [
+  const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
       lastModified: new Date(),
-      changeFrequency: 'daily' as const,
+      changeFrequency: 'daily',
       priority: 1,
     },
     {
       url: `${baseUrl}/blog`,
       lastModified: new Date(),
-      changeFrequency: 'daily' as const,
+      changeFrequency: 'daily',
       priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/blog/all`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.85,
     },
     {
       url: `${baseUrl}/portfolio`,
       lastModified: new Date(),
-      changeFrequency: 'weekly' as const,
+      changeFrequency: 'weekly',
       priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/feed.xml`,
+      lastModified: new Date(),
+      changeFrequency: 'hourly',
+      priority: 0.4,
     },
   ];
 
   try {
-    // 카테고리 목록 가져오기
     const categories = await prisma.category.findMany({
       select: {
         slug: true,
@@ -34,7 +44,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     });
 
-    // 카테고리별 포스트 목록 페이지 URL 생성
     const categoryPages = categories.map((category) => ({
       url: `${baseUrl}/blog/category/${category.slug}`,
       lastModified: category.createdAt || new Date(),
@@ -42,7 +51,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     }));
 
-    // 모든 포스트 가져오기
     const posts = await prisma.post.findMany({
       select: {
         slug: true,
@@ -55,15 +63,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     });
 
-    // 개별 포스트 페이지 URL 생성
     const postPages = posts.map((post) => ({
-      url: `${baseUrl}/blog/category/${post.category?.slug || 'uncategorized'}/post/${post.slug}`,
+      url: `${baseUrl}/blog/category/${post.category?.slug || 'uncategorized'}/post/${encodeURIComponent(post.slug)}`,
       lastModified: post.updatedAt || new Date(),
       changeFrequency: 'monthly' as const,
       priority: 0.6,
     }));
 
-    // 태그 목록 가져오기
     const tags = await prisma.tag.findMany({
       select: {
         name: true,
@@ -71,20 +77,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     });
 
-    // 태그 페이지 URL 생성
     const tagPages = tags.map((tag) => ({
-      url: `${baseUrl}/blog/tags/${tag.name}`,
+      url: `${baseUrl}/blog/all?tags=${encodeURIComponent(tag.name)}`,
       lastModified: tag.createdAt || new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.5,
     }));
 
-    // 모든 sitemap 항목 합치기
     return [...staticPages, ...categoryPages, ...postPages, ...tagPages];
   } catch (error) {
     console.error('Sitemap generation error:', error);
-
-    // 에러 발생 시 정적 페이지만 반환
     return staticPages;
   }
 }

--- a/src/shared/consts/baseUrl.ts
+++ b/src/shared/consts/baseUrl.ts
@@ -1,1 +1,26 @@
-export const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http//localhost:3000';
+export const baseUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000').replace(/\/$/, '');
+
+export const toAbsoluteUrl = (path: string) => {
+  if (!path) return baseUrl;
+  if (path.startsWith('http://') || path.startsWith('https://')) return path;
+  return `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+};
+
+export const getPostPath = (categorySlug: string | null | undefined, postSlug: string) =>
+  `/blog/category/${categorySlug || 'uncategorized'}/post/${encodeURIComponent(postSlug)}`;
+
+export const getPostUrl = (categorySlug: string | null | undefined, postSlug: string) =>
+  toAbsoluteUrl(getPostPath(categorySlug, postSlug));
+
+export const extractDescription = (content: string, maxLength = 160) => {
+  const plainText = content
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (plainText.length <= maxLength) {
+    return plainText;
+  }
+
+  return `${plainText.substring(0, maxLength).replace(/\s+\S*$/, '')}...`;
+};


### PR DESCRIPTION
## Summary
- `baseUrl` 오타(`http//`) 수정과 절대 URL 헬퍼 추가
- `/feed.xml` RSS 피드, 사이트/포스트 동적 OG 이미지 추가
- 포스트 JSON-LD·canonical·robots/sitemap을 실제 라우트에 맞게 정리

## Test plan
- [ ] `/feed.xml` 최신 글 RSS 응답 확인
- [ ] `/opengraph-image` 및 포스트 `opengraph-image` 렌더 확인
- [ ] 포스트 페이지 head의 canonical/og/twitter/json-ld 확인
- [ ] `/robots.txt`, `/sitemap.xml` 허용 경로·태그 URL 확인


Made with [Cursor](https://cursor.com)