### PR TITLE
feat: 블로그 검색·조회 분석 이벤트 추가

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -7,7 +7,9 @@ import type { Metadata } from 'next';
 import type { PostResponse } from '@/entities/post/model/post';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
+import { PostViewTracker } from '@/widgets/post/ui/PostViewTracker';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
 const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'));
 
@@ -157,6 +159,13 @@ export default async function PostPage({
     <>
       {/* SEO를 위한 구조화 데이터 */}
       <PostStructuredData post={post} />
+      <Suspense fallback={null}>
+        <PostViewTracker
+          postId={post.id ?? post.slug ?? 'unknown'}
+          slug={post.slug ?? decodedSlug}
+          categorySlug={post.category?.slug}
+        />
+      </Suspense>
 
       <div className='mx-4 max-w-4xl lg:mx-auto'>
         <PostBackButton href={backHref} />

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@tsparticles/slim": "^3.8.1",
     "@types/bcryptjs": "^3.0.0",
     "@types/three": "^0.172.0",
+    "@vercel/analytics": "^2.0.1",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.3.0(@babel/core@7.27.4)(@types/node@20.17.57)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3371,6 +3374,35 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@4.5.0':
     resolution: {integrity: sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==}
@@ -11408,6 +11440,11 @@ snapshots:
   '@use-gesture/react@10.3.1(react@19.2.1)':
     dependencies:
       '@use-gesture/core': 10.3.1
+      react: 19.2.1
+
+  '@vercel/analytics@2.0.1(next@16.3.0(@babel/core@7.27.4)(@types/node@20.17.57)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    optionalDependencies:
+      next: 16.3.0(@babel/core@7.27.4)(@types/node@20.17.57)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
 
   '@vitejs/plugin-react@4.5.0(vite@6.3.5(@types/node@20.17.57)(jiti@2.4.2)(yaml@2.8.0))':

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -7,6 +7,7 @@ import { SessionProvider } from 'next-auth/react';
 import { ToastProvider } from '@/shared/ui/toast';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { CosmosCursor } from '@/widgets/home';
+import { AnalyticsProvider } from '@/shared/ui/AnalyticsProvider';
 
 function makeQueryClient() {
   return new QueryClient({
@@ -43,6 +44,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         <ToastProvider maxToasts={5}>
           <SessionProvider>
             <CosmosCursor />
+            <AnalyticsProvider />
             {children}
           </SessionProvider>
         </ToastProvider>

--- a/src/shared/lib/analytics.ts
+++ b/src/shared/lib/analytics.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { track as vercelTrack } from '@vercel/analytics';
+
+type AnalyticsProps = Record<string, string | number | boolean | null | undefined>;
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+const sanitizeProps = (props?: AnalyticsProps) => {
+  if (!props) return undefined;
+  const next: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (value === undefined || value === null) continue;
+    next[key] = value;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+};
+
+export const trackEvent = (name: string, props?: AnalyticsProps) => {
+  if (typeof window === 'undefined') return;
+
+  const cleanProps = sanitizeProps(props);
+
+  try {
+    vercelTrack(name, cleanProps);
+  } catch {
+    // analytics must never break UX
+  }
+
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', name, cleanProps);
+  }
+};
+
+export const AnalyticsEvents = {
+  blogSearchSubmit: 'blog_search_submit',
+  blogSearchZeroResult: 'blog_search_zero_result',
+  blogPostView: 'blog_post_view',
+} as const;

--- a/src/shared/ui/AnalyticsProvider.tsx
+++ b/src/shared/ui/AnalyticsProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Analytics } from '@vercel/analytics/react';
+import Script from 'next/script';
+
+const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export const AnalyticsProvider = () => {
+  return (
+    <>
+      <Analytics />
+      {gaId ? (
+        <>
+          <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy='afterInteractive' />
+          <Script id='ga4-init' strategy='afterInteractive'>
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              window.gtag = gtag;
+              gtag('js', new Date());
+              gtag('config', '${gaId}', { anonymize_ip: true });
+            `}
+          </Script>
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -1,6 +1,9 @@
 'use client';
+
+import { useEffect, useRef } from 'react';
 import { usePost } from '@/features/post/model';
 import { useSearchParams } from 'next/navigation';
+import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
 import { RecentPosts } from './RecentPosts';
 import { PostList } from './PostList';
 import { NoResults } from './NoResults';
@@ -8,27 +11,56 @@ import { BlogSectionTitle } from './BlogSectionTitle';
 
 export const BlogMainPage = () => {
   const searchParams = useSearchParams();
-  const search = searchParams.get('search');
+  const search = searchParams.get('search') ?? '';
+  const category = searchParams.get('category') ?? '';
+  const tagsParam = searchParams.get('tags') ?? '';
+  const tags = tagsParam.split(',').filter(Boolean);
+  const hasFilters = Boolean(search || category || tags.length > 0);
+
   const { posts, isLoading } = usePost({
-    search: search ?? '',
-    category: searchParams.get('category') ?? '',
-    tags: searchParams.get('tags') ?? '',
+    search,
+    category,
+    tags: tagsParam,
     page: 1,
     limit: 10,
   });
 
   const postsData = posts?.pages?.flatMap((page) => page.data ?? []) ?? [];
+  const trackedKeyRef = useRef<string>('');
 
-  // 로딩 중이 아니고 결과가 없을 때
+  useEffect(() => {
+    if (isLoading || !hasFilters) return;
+
+    const key = `${search}|${category}|${tagsParam}|${postsData.length}`;
+    if (trackedKeyRef.current === key) return;
+    trackedKeyRef.current = key;
+
+    trackEvent(AnalyticsEvents.blogSearchSubmit, {
+      query_length: search.length,
+      has_query: Boolean(search),
+      has_category: Boolean(category),
+      has_tag: tags.length > 0,
+      tag_count: tags.length,
+      result_count: postsData.length,
+    });
+
+    if (postsData.length === 0) {
+      trackEvent(AnalyticsEvents.blogSearchZeroResult, {
+        query_length: search.length,
+        has_query: Boolean(search),
+        has_category: Boolean(category),
+        has_tag: tags.length > 0,
+        tag_count: tags.length,
+      });
+    }
+  }, [isLoading, hasFilters, search, category, tagsParam, tags.length, postsData.length]);
+
   if (!isLoading && postsData.length === 0) {
-    const category = searchParams.get('category');
-    const tags = searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
-
     return (
-      <div className='max-w-4xl mx-auto w-full'>
+      <div className='mx-auto w-full max-w-4xl'>
         <NoResults
-          searchTerm={search ?? undefined}
-          category={category ?? undefined}
+          searchTerm={search || undefined}
+          category={category || undefined}
           tags={tags.length > 0 ? tags : undefined}
         />
       </div>
@@ -39,7 +71,7 @@ export const BlogMainPage = () => {
   const restPosts = postsData.slice(6);
 
   return (
-    <div className='max-w-4xl mx-auto w-full'>
+    <div className='mx-auto w-full max-w-4xl'>
       <BlogSectionTitle subtitle='최근에 올라온 글'>Recent</BlogSectionTitle>
       <RecentPosts posts={recentPosts} isLoading={isLoading} />
 

--- a/src/widgets/post/ui/PostViewTracker.tsx
+++ b/src/widgets/post/ui/PostViewTracker.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
+
+type PostViewTrackerProps = {
+  postId: string | number;
+  slug: string;
+  categorySlug?: string | null;
+};
+
+export const PostViewTracker = ({ postId, slug, categorySlug }: PostViewTrackerProps) => {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const utmSource = searchParams.get('utm_source');
+    const fromParam = searchParams.get('from');
+    const hasSearch = Boolean(searchParams.get('search') || searchParams.get('tags') || searchParams.get('category'));
+
+    let from = 'direct';
+    if (fromParam) from = fromParam;
+    else if (utmSource === 'rss' || utmSource === 'feed') from = 'rss';
+    else if (document.referrer.includes('/blog/all') || hasSearch) from = 'search';
+    else if (document.referrer.includes('/blog/category/')) from = 'category';
+    else if (document.referrer) from = 'referral';
+
+    trackEvent(AnalyticsEvents.blogPostView, {
+      post_id: String(postId),
+      slug,
+      category: categorySlug ?? 'uncategorized',
+      from,
+    });
+  }, [postId, slug, categorySlug, searchParams]);
+
+  return null;
+};

--- a/src/widgets/post/ui/index.ts
+++ b/src/widgets/post/ui/index.ts
@@ -5,7 +5,7 @@ export { default as BlogHeader } from './BlogHeader';
 export { default as Sidebar } from './Sidebar';
 export { MobileNavbar } from './MobileNavbar';
 export { SpaceBackground } from './SpaceBackground';
-export { PostBackButton } from './PostBackButton';
+export { PostViewTracker } from './PostViewTracker';
 export { PostsLayoutShell } from './PostsLayoutShell';
 export { BlogSectionTitle } from './BlogSectionTitle';
 export { SearchBar } from './SearchBar';


### PR DESCRIPTION
## Summary
- `@vercel/analytics` 도입 및 선택적 GA4(`NEXT_PUBLIC_GA_MEASUREMENT_ID`) 연동
- 검색 제출/무결과, 포스트 조회 이벤트를 수집해 SEO·검색 성과를 수치화할 기반을 마련

## Events
- `blog_search_submit`: query_length, has_query, has_category, has_tag, tag_count, result_count
- `blog_search_zero_result`: 필터 결과가 0건일 때
- `blog_post_view`: post_id, slug, category, from(direct|search|category|rss|referral)

## Test plan
- [ ] 로컬/프리뷰에서 `/blog/all` 검색 시 Vercel Analytics custom event 확인
- [ ] 결과 0건일 때 `blog_search_zero_result` 확인
- [ ] 포스트 상세 진입 시 `blog_post_view` 확인
- [ ] (선택) `.env`에 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 설정 후 GA4 DebugView 확인


Made with [Cursor](https://cursor.com)