### PR TITLE
perf: 블로그 목록·상세 Lighthouse 성능 개선

### DIFF
--- a/app/(public)/blog/(posts)/all/page.tsx
+++ b/app/(public)/blog/(posts)/all/page.tsx
@@ -1,10 +1,25 @@
 import { Suspense } from 'react';
+import { getPostList } from '@/features/post/api/post-api';
+import type { GetPostListResponse } from '@/features/post/model';
 import { BlogMainPage } from '@/widgets/post/ui';
 
-const BlogAllPage = () => {
+const BlogAllPage = async () => {
+  let initialPosts: GetPostListResponse | undefined;
+  try {
+    initialPosts = await getPostList({
+      search: '',
+      category: '',
+      tags: '',
+      page: 1,
+      limit: 10,
+    });
+  } catch {
+    initialPosts = undefined;
+  }
+
   return (
-    <Suspense fallback={<div className='max-w-4xl mx-auto w-full py-8 text-white/70'>불러오는 중...</div>}>
-      <BlogMainPage />
+    <Suspense fallback={<div className='mx-auto w-full max-w-4xl py-8 text-white/70'>불러오는 중...</div>}>
+      <BlogMainPage initialPosts={initialPosts} />
     </Suspense>
   );
 };

--- a/app/(public)/blog/(posts)/category/[slug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/page.tsx
@@ -6,8 +6,16 @@ import { useCategoryPosts } from '@/features/category/model';
 import { PostListCardSkeleton } from '@/shared/ui/skeleton';
 
 export default function BlogPostPage() {
-  const { slug } = useParams();
-  const { data: categoryPosts, isLoading: isCategoryPostsLoading } = useCategoryPosts(slug as string, 1, 10);
+  const { slug: rawSlug } = useParams();
+  const slug = (() => {
+    const value = String(rawSlug ?? '');
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  })();
+  const { data: categoryPosts, isLoading: isCategoryPostsLoading } = useCategoryPosts(slug, 1, 10);
 
   if (isCategoryPostsLoading) {
     return (

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -1,18 +1,20 @@
-import { getPostBySlug } from '@/features/post/api/post-api';
-import { formatDateToYMD } from '@/shared/utils';
-import dynamic from 'next/dynamic';
-import { CommentSection } from '@/features/comment/ui';
-import { PostSummary } from '@/shared/ui/PostSummary';
 import type { Metadata } from 'next';
+import dynamic from 'next/dynamic';
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 import type { PostResponse } from '@/entities/post/model/post';
+import { CommentSection } from '@/features/comment/ui';
+import { getPostBySlug } from '@/features/post/api/post-api';
+import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
+import PostHtmlViewer from '@/shared/ui/PostHtmlViewer';
+import { formatDateToYMD } from '@/shared/utils';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
 import { PostViewTracker } from '@/widgets/post/ui/PostViewTracker';
-import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
-import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
 
-const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'));
+const PostSummary = dynamic(() => import('@/shared/ui/PostSummary').then((mod) => mod.PostSummary), {
+  loading: () => <div className='mb-6 min-h-[88px]' aria-hidden />,
+});
 
 export async function generateMetadata({ params }: { params: Promise<{ postSlug: string }> }): Promise<Metadata> {
   const { postSlug } = await params;
@@ -115,11 +117,7 @@ const PostStructuredData = ({ post }: { post: PostResponse }) => {
   return <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />;
 };
 
-export default async function PostPage({
-  params,
-}: {
-  params: Promise<{ slug: string; postSlug: string }>;
-}) {
+export default async function PostPage({ params }: { params: Promise<{ slug: string; postSlug: string }> }) {
   const { slug, postSlug } = await params;
   const decodedSlug = decodeURIComponent(postSlug);
   const categorySlug = decodeURIComponent(slug);
@@ -188,7 +186,7 @@ export default async function PostPage({
             </div>
           )}
 
-          <div className='relative z-10 p-2'>
+          <div className='relative z-10 mb-2 min-h-[88px] p-2'>
             <PostSummary
               post={{
                 id: post.id ?? post.slug ?? 'unknown',
@@ -200,7 +198,7 @@ export default async function PostPage({
           </div>
 
           <div className='relative z-10'>
-            <NovelViewer content={post.content ?? ''} />
+            <PostHtmlViewer content={post.content ?? ''} />
           </div>
         </section>
 

--- a/app/(public)/blog/page.tsx
+++ b/app/(public)/blog/page.tsx
@@ -1,138 +1,19 @@
 'use client';
 
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { Suspense, useState, useEffect } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { Bloom, DepthOfField, EffectComposer } from '@react-three/postprocessing';
-import { MeshReflectorMaterial } from '@react-three/drei';
-import { Macintosh, ComputerBackground } from '@/widgets/post/ui';
-import { CanvasLoader, AnimatedText, WatchRobot, HelloBot, MoveBot, FloatingActionButton } from '@/shared/ui';
-import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 
-function AnimatedCamera({ cameraPos }: { cameraPos: { x: number; y: number; z: number } }) {
-  const { camera } = useThree();
-  useFrame(() => {
-    camera.position.set(cameraPos.x, cameraPos.y, cameraPos.z);
-    camera.updateProjectionMatrix();
-  });
-  return null;
-}
+const BlogLandingScene = dynamic(() => import('@/widgets/post/ui/BlogLandingScene'), {
+  ssr: false,
+  loading: () => (
+    <main className='fixed inset-0 z-10 flex h-full w-full items-center justify-center bg-black'>
+      <div className='text-center text-white/80' role='status' aria-live='polite'>
+        <div className='mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-2 border-white/30 border-t-white' />
+        <p className='text-sm'>3D 블로그 로딩 중...</p>
+      </div>
+    </main>
+  ),
+});
 
 export default function BlogPage() {
-  const router = useRouter();
-  const [htmlScale, setHtmlScale] = useState(1);
-  const [htmlOpacity, setHtmlOpacity] = useState(1);
-  const [isNavigating, setIsNavigating] = useState(false);
-
-  // 마우스 휠로 scale 조절 및 라우팅
-  const handleWheel = (e: React.WheelEvent) => {
-    if (!isNavigating) {
-      setHtmlScale((prev) => {
-        let next = prev + e.deltaY * 0.01;
-        if (next < 1) {
-          next = 1;
-        }
-        if (next > 8) {
-          next = 8;
-        }
-        return next;
-      });
-    }
-  };
-
-  useEffect(() => {
-    setHtmlOpacity(1 - (htmlScale - 1) / 8);
-  }, [htmlScale]);
-
-  useEffect(() => {
-    if (!isNavigating && htmlScale >= 8) {
-      setIsNavigating(true);
-      // 스크롤이 끝까지 도달하면 /blog/all로 라우팅
-      setTimeout(() => {
-        router.push('/blog/all');
-      }, 300);
-    }
-  }, [htmlScale, isNavigating, router]);
-
-  return (
-    <main className='fixed inset-0 z-10 w-full h-full bg-gray-700' onWheel={handleWheel} style={{ overflow: 'hidden' }}>
-      <AnimatePresence>
-        <motion.div
-          key='mac-canvas'
-          initial={{ opacity: 0, scale: 1 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0, y: 700 }}
-          transition={{ duration: 0.6, ease: 'easeInOut' }}
-          className='w-full h-full'
-        >
-          <Canvas
-            dpr={[1, 1.5]}
-            camera={{ fov: 70, near: 1, zoom: 15, position: [-0.2, 1.5, 8.88] }}
-            eventPrefix='client'
-          >
-            <color attach='background' args={['black']} />
-            <hemisphereLight intensity={0.15} groundColor='black' />
-            <spotLight
-              decay={0}
-              position={[10, 20, 10]}
-              angle={0.12}
-              penumbra={1}
-              intensity={1}
-              castShadow
-              shadow-mapSize={1024}
-            />
-            <Suspense fallback={<CanvasLoader />}>
-              <Macintosh
-                scale={0.25}
-                htmlScale={htmlScale}
-                htmlOpacity={htmlOpacity}
-                showFullPage={false}
-                position={[-0.08, 0.08, 0]}
-                rotation={[0, Math.PI / 6, 0]}
-              />
-              <ComputerBackground scale={0.11} position={[0, 0.001, 0]} />
-              <AnimatedText />
-              <WatchRobot scale={0.002} position={[0.1, 0.12, 0.3]} rotation={[0, -Math.PI / 1.5, 0]} />
-              <HelloBot scale={0.06} position={[0.18, 0.18, -0.16]} rotation={[0, -Math.PI / 4, 0]} />
-              <MoveBot scale={0.05} position={[0.4, 0, 0.7]} rotation={[0, -Math.PI / 4, 0]} />
-              <AnimatedCamera cameraPos={{ x: -0.16, y: 1.4, z: 7.5 }} />
-              <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
-                <planeGeometry args={[50, 50]} />
-                <MeshReflectorMaterial
-                  blur={[300, 30]}
-                  resolution={2048}
-                  mixBlur={1}
-                  mixStrength={180}
-                  roughness={1}
-                  depthScale={1.2}
-                  minDepthThreshold={0.4}
-                  maxDepthThreshold={1.4}
-                  color='#202020'
-                  metalness={0.8}
-                />
-              </mesh>
-              <EffectComposer enableNormalPass={false}>
-                <Bloom luminanceThreshold={0} mipmapBlur luminanceSmoothing={0.0} intensity={5} />
-                <DepthOfField target={[0, 0, 13]} focalLength={0.3} bokehScale={15} height={700} />
-              </EffectComposer>
-            </Suspense>
-          </Canvas>
-          <FloatingActionButton />
-
-          {/* 스크롤 힌트 */}
-          <div className='absolute bottom-8 left-1/2 transform -translate-x-1/2 text-white text-center'>
-            <div className='animate-pulse duration-[3000ms]'>
-              <p className='text-sm mb-2 opacity-80'>스크롤하여 블로그 보기</p>
-              <div className='w-6 h-10 border-2 border-white/70 rounded-full mx-auto relative'>
-                <div
-                  className='w-1 h-3 bg-white rounded-full mx-auto mt-2 transform translate-y-0 animate-bounce duration-[2500ms]'
-                  style={{ animationTimingFunction: 'cubic-bezier(0.4, 0, 0.6, 1)' }}
-                />
-              </div>
-            </div>
-          </div>
-        </motion.div>
-      </AnimatePresence>
-    </main>
-  );
+  return <BlogLandingScene />;
 }

--- a/app/api/category/[slug]/route.ts
+++ b/app/api/category/[slug]/route.ts
@@ -108,7 +108,17 @@ import { auth } from '@/shared/utils/auth';
  */
 export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   try {
-    const { slug } = await params;
+    const { slug: rawSlug } = await params;
+    let slug = rawSlug;
+    for (let i = 0; i < 3; i++) {
+      try {
+        const decoded = decodeURIComponent(slug);
+        if (decoded === slug) break;
+        slug = decoded;
+      } catch {
+        break;
+      }
+    }
     const { searchParams } = new URL(request.url);
     const search = searchParams.get('search') || '';
     const page = Number.parseInt(searchParams.get('page') || '1');

--- a/app/globals.css
+++ b/app/globals.css
@@ -678,6 +678,26 @@ pre {
   mix-blend-mode: multiply;
 }
 
+@keyframes blog-planet-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+.blog-planet-float {
+  animation: blog-planet-float var(--float-duration, 8s) ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-planet-float {
+    animation: none;
+  }
+}
+
 .void-os-desktop {
   background-color: #050816;
   background-image:

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,51 +1,62 @@
 'use client';
+
 import { motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
 
 const transitionVariants = {
   initial: {
     x: '100%',
-    width: '100%',
   },
   animate: {
-    x: '0%',
-    width: '0%',
+    x: '100%',
   },
   exit: {
     x: ['0%', '100%'],
-    width: ['0%', '100%'],
   },
 };
 
+/**
+ * 페이지 전환 오버레이.
+ * width 애니메이션은 CLS를 유발하므로 transform만 사용.
+ * 블로그 읽기 경로에서는 오버레이를 생략해 LCP/CLS를 지킨다.
+ */
 export default function Template({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const skipTransition = pathname?.startsWith('/blog');
+
+  if (skipTransition) {
+    return children;
+  }
+
   return (
     <>
       {children}
-      {/* 첫 번째 레이어 */}
       <motion.div
-        className='fixed top-0 bottom-0 right-full w-screen h-screen z-30 bg-gradient-to-br from-slate-800 to-slate-900'
+        className='pointer-events-none fixed inset-y-0 right-0 z-30 h-screen w-screen origin-right bg-gradient-to-br from-slate-800 to-slate-900'
         variants={transitionVariants}
         initial='initial'
         animate='animate'
         exit='exit'
         transition={{ delay: 0, duration: 0.7, ease: 'easeInOut' }}
+        aria-hidden
       />
-      {/* 두 번째 레이어 */}
       <motion.div
-        className='fixed top-0 bottom-0 right-full w-screen h-screen z-31 bg-gradient-to-br from-gray-800 to-blue-900'
+        className='pointer-events-none fixed inset-y-0 right-0 z-31 h-screen w-screen origin-right bg-gradient-to-br from-gray-800 to-blue-900'
         variants={transitionVariants}
         initial='initial'
         animate='animate'
         exit='exit'
         transition={{ delay: 0.1, duration: 0.7, ease: 'easeInOut' }}
+        aria-hidden
       />
-      {/* 세 번째 레이어 */}
       <motion.div
-        className='fixed top-0 bottom-0 right-full w-screen h-screen z-32 bg-gradient-to-br from-blue-900 to-indigo-900'
+        className='pointer-events-none fixed inset-y-0 right-0 z-32 h-screen w-screen origin-right bg-gradient-to-br from-blue-900 to-indigo-900'
         variants={transitionVariants}
         initial='initial'
         animate='animate'
         exit='exit'
         transition={{ delay: 0.2, duration: 0.7, ease: 'easeInOut' }}
+        aria-hidden
       />
     </>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   experimental: {
     // TypeScript 7은 JS Compiler API가 없어 로컬 tsc로 타입체크
     useTypeScriptCli: true,
+    optimizePackageImports: ['lucide-react', 'framer-motion', 'date-fns'],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "framer-motion": "^12.10.5",
     "gsap": "^3.13.0",
     "install": "^0.13.0",
+    "isomorphic-dompurify": "^3.22.0",
     "jest-fixed-jsdom": "^0.0.9",
     "leva": "^0.10.0",
     "lowlight": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       install:
         specifier: ^0.13.0
         version: 0.13.0
+      isomorphic-dompurify:
+        specifier: ^3.22.0
+        version: 3.22.0
       jest-fixed-jsdom:
         specifier: ^0.0.9
         version: 0.0.9(jest-environment-jsdom@29.7.0)
@@ -326,10 +329,10 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@30.0.1)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@7.0.2)(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0))
+        version: 3.1.0(typescript@7.0.2)(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@30.0.1)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0))
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -367,6 +370,14 @@ packages:
     resolution: {integrity: sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==}
     peerDependencies:
       openapi-types: '>=7'
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@auth/core@0.39.1':
     resolution: {integrity: sha512-McD8slui0oOA1pjR5sPjLPl5Zm//nLP/8T3kr8hxIsvNLvsiudYvPHhDFPjh1KcZ2nFxCkZmP6bRxaaPd/AnLA==}
@@ -628,6 +639,10 @@ packages:
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
 
@@ -658,6 +673,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@daybrush/utils@1.13.0':
     resolution: {integrity: sha512-ALK12C6SQNNHw1enXK+UO8bdyQ+jaWNQ1Af7Z3FNxeAwjYhQT7do+TRE4RASAJ3ObaS2+TJ7TXR3oz2Gzbw0PQ==}
@@ -901,6 +952,15 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@0.7.3':
     resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
@@ -3968,6 +4028,10 @@ packages:
   css-to-mat@1.1.1:
     resolution: {integrity: sha512-kvpxFYZb27jRd2vium35G7q5XZ2WJ9rWjDUMNT36M3Hc41qCrLXFM5iEKMGXcrPsKfXEN+8l/riB4QzwwwiEyQ==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
@@ -4156,6 +4220,10 @@ packages:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -4199,6 +4267,9 @@ packages:
 
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.1.0:
     resolution: {integrity: sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==}
@@ -4323,6 +4394,9 @@ packages:
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -4368,6 +4442,10 @@ packages:
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -5024,6 +5102,10 @@ packages:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -5306,6 +5388,10 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isomorphic-dompurify@3.22.0:
+    resolution: {integrity: sha512-cz/BkSODnQir4IV2quqbuEHhAGz4MAYGvhoemsxuwMpY/oZbRHlNjPLPyIQ0fdULiwDPUE+OHPwWb6XTEiNk1A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -5541,6 +5627,15 @@ packages:
       canvas:
         optional: true
 
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -5710,6 +5805,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -5777,6 +5876,9 @@ packages:
 
   mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -6301,6 +6403,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -7330,6 +7435,13 @@ packages:
     peerDependencies:
       '@tiptap/core': ^2.0.3
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -7344,12 +7456,20 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-sitter-json@0.24.8:
     resolution: {integrity: sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==}
@@ -7542,6 +7662,10 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
@@ -7765,6 +7889,10 @@ packages:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -7788,6 +7916,10 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
@@ -7800,9 +7932,21 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7874,6 +8018,10 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
@@ -8024,6 +8172,21 @@ snapshots:
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
       z-schema: 5.0.5
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@auth/core@0.39.1':
     dependencies:
@@ -8282,6 +8445,10 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
@@ -8319,6 +8486,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@daybrush/utils@1.13.0': {}
 
@@ -8505,6 +8696,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@0.7.3': {}
 
@@ -12059,6 +12252,11 @@ snapshots:
       '@daybrush/utils': 1.13.0
       '@scena/matrix': 1.1.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.1.0: {}
 
   css.escape@1.5.1: {}
@@ -12267,6 +12465,13 @@ snapshots:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -12302,6 +12507,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.5.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.1.0:
     dependencies:
@@ -12404,6 +12611,10 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -12439,6 +12650,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.0: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -13255,6 +13468,12 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   http-proxy-agent@5.0.0:
@@ -13505,6 +13724,14 @@ snapshots:
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
+
+  isomorphic-dompurify@3.22.0:
+    dependencies:
+      dompurify: 3.4.13
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -13963,6 +14190,32 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -14126,6 +14379,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -14214,6 +14469,8 @@ snapshots:
   mdast-util-to-string@3.2.0:
     dependencies:
       '@types/mdast': 3.0.15
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -14848,6 +15105,10 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.0
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -16092,6 +16353,12 @@ snapshots:
       markdown-it-task-lists: 2.1.1
       prosemirror-markdown: 1.13.2
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -16107,9 +16374,17 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
   tr46@0.0.3: {}
 
   tr46@3.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -16340,6 +16615,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici@8.10.0: {}
+
   unified@10.1.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -16515,13 +16792,13 @@ snapshots:
       jiti: 2.4.2
       yaml: 2.8.0
 
-  vitest-mock-extended@3.1.0(typescript@7.0.2)(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)):
+  vitest-mock-extended@3.1.0(typescript@7.0.2)(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@30.0.1)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)):
     dependencies:
       ts-essentials: 10.1.1(typescript@7.0.2)
       typescript: 7.0.2
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)
+      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@30.0.1)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0)
 
-  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0):
+  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(jsdom@30.0.1)(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.1.4
       '@vitest/mocker': 3.1.4(msw@2.8.6(@types/node@20.17.57)(typescript@7.0.2))(vite@6.3.5(@types/node@20.17.57)(jiti@2.4.2)(yaml@2.8.0))
@@ -16547,7 +16824,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.17.57
-      jsdom: 20.0.3
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -16585,6 +16862,10 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -16602,6 +16883,8 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webidl-conversions@8.0.1: {}
+
   whatwg-encoding@2.0.0:
     dependencies:
       iconv-lite: 0.6.3
@@ -16610,10 +16893,28 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  whatwg-mimetype@5.0.0: {}
+
   whatwg-url@11.0.0:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -16704,6 +17005,8 @@ snapshots:
       repeat-string: 1.6.1
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
 
   xml@1.0.1: {}
 

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -6,8 +6,14 @@ import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/re
 import { SessionProvider } from 'next-auth/react';
 import { ToastProvider } from '@/shared/ui/toast';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
-import { CosmosCursor } from '@/widgets/home';
 import { AnalyticsProvider } from '@/shared/ui/AnalyticsProvider';
+import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
+
+const CosmosCursor = dynamic(
+  () => import('@/widgets/home/ui/CosmosCursor').then((mod) => mod.CosmosCursor),
+  { ssr: false },
+);
 
 function makeQueryClient() {
   return new QueryClient({
@@ -35,6 +41,14 @@ export function getQueryClient() {
   return browserQueryClient;
 }
 
+const HomeOnlyCosmosCursor = () => {
+  const pathname = usePathname();
+  if (pathname !== '/') {
+    return null;
+  }
+  return <CosmosCursor />;
+};
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 
@@ -43,7 +57,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       <NuqsAdapter>
         <ToastProvider maxToasts={5}>
           <SessionProvider>
-            <CosmosCursor />
+            <HomeOnlyCosmosCursor />
             <AnalyticsProvider />
             {children}
           </SessionProvider>

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -35,6 +35,21 @@ type PathParameters<P extends Path, M extends Method<P>> = RequestPathParams<P, 
   ? {}
   : { path: RequestPathParams<P, M> };
 
+/** path param을 유니코드로 정규화. 인코딩은 fetch/URL이 1회만 수행 */
+const toPathSegment = (value: string | number) => {
+  let decoded = String(value);
+  for (let i = 0; i < 3; i++) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+};
+
 type FetcherParams<P extends Path, M extends Method<P>> = {
   url: P;
   method: M;
@@ -60,15 +75,19 @@ export const fetcher = async <P extends Path, M extends Method<P>>({
 
   if ('path' in restParams) {
     const pathObj = restParams.path as Record<string, string | number>;
-    const replacedPathUrl = finalUrl.replace(/\{(\w+)\}/g, (match, key) => String(pathObj[key] || match));
+    const replacedPathUrl = finalUrl.replace(/\{(\w+)\}/g, (match, key) => {
+      const value = pathObj[key];
+      if (value == null) return match;
+      return toPathSegment(value);
+    });
     finalUrl = replacedPathUrl;
   }
 
-  // 서버 환경에서 finalUrl이 /로 시작하면 절대경로로 변환
+  // 서버 환경에서 finalUrl이 /로 시작하면 절대경로로 변환 (URL이 path를 1회 인코딩)
   const isServer = typeof window === 'undefined';
   if (isServer && finalUrl.startsWith('/')) {
     const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-    finalUrl = baseUrl + finalUrl;
+    finalUrl = new URL(finalUrl, baseUrl).href;
   }
 
   const res = await fetch(finalUrl, {

--- a/src/shared/ui/AnalyticsProvider.tsx
+++ b/src/shared/ui/AnalyticsProvider.tsx
@@ -11,8 +11,8 @@ export const AnalyticsProvider = () => {
       <Analytics />
       {gaId ? (
         <>
-          <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy='afterInteractive' />
-          <Script id='ga4-init' strategy='afterInteractive'>
+          <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy='lazyOnload' />
+          <Script id='ga4-init' strategy='lazyOnload'>
             {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}

--- a/src/shared/ui/NovelViewer.tsx
+++ b/src/shared/ui/NovelViewer.tsx
@@ -1,13 +1,11 @@
 'use client';
 import { preprocessHTML } from '../utils';
-import { defaultExtensions } from './TextEditor/extensions';
+import { viewerExtensions } from './TextEditor/viewerExtensions';
 import { EditorContent } from 'novel';
 
 type NovelViewerProps = {
   content: string;
 };
-
-const extensions = [...defaultExtensions];
 
 export default function NovelViewer({ content }: NovelViewerProps) {
   const processedValue = content ? preprocessHTML(content) : content;
@@ -15,7 +13,7 @@ export default function NovelViewer({ content }: NovelViewerProps) {
   return (
     <div className='blog-prose'>
       <EditorContent
-        extensions={extensions}
+        extensions={viewerExtensions}
         immediatelyRender={false}
         editable={false}
         initialContent={processedValue as any}

--- a/src/shared/ui/PostHtmlViewer.tsx
+++ b/src/shared/ui/PostHtmlViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { preprocessHTML } from '@/shared/utils';
+import { preprocessHTML, sanitizePostHtml, sanitizeSvgHtml } from '@/shared/utils';
 
 type PostHtmlViewerProps = {
   content: string;
@@ -28,7 +28,8 @@ const enhanceCodeBlocks = async (root: HTMLElement) => {
         const { svg } = await mermaid.render(id, source);
         const pre = block.closest('pre');
         if (pre) {
-          pre.outerHTML = `<div class="mermaid-diagram my-4 overflow-x-auto">${svg}</div>`;
+          const safeSvg = sanitizeSvgHtml(svg);
+          pre.outerHTML = `<div class="mermaid-diagram my-4 overflow-x-auto">${safeSvg}</div>`;
         }
       } catch {
         // 원본 코드 블록 유지
@@ -43,7 +44,7 @@ const enhanceCodeBlocks = async (root: HTMLElement) => {
  */
 export default function PostHtmlViewer({ content }: PostHtmlViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const html = content ? preprocessHTML(content) : '';
+  const html = content ? sanitizePostHtml(preprocessHTML(content)) : '';
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -52,12 +53,7 @@ export default function PostHtmlViewer({ content }: PostHtmlViewerProps) {
 
   return (
     <div className='blog-prose'>
-      <div
-        ref={containerRef}
-        className='ProseMirror'
-        // 관리자 작성 HTML — XSS는 관리자 권한 콘텐츠로 제한됨
-        dangerouslySetInnerHTML={{ __html: typeof html === 'string' ? html : '' }}
-      />
+      <div ref={containerRef} className='ProseMirror' dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
 }

--- a/src/shared/ui/PostHtmlViewer.tsx
+++ b/src/shared/ui/PostHtmlViewer.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { preprocessHTML } from '@/shared/utils';
+
+type PostHtmlViewerProps = {
+  content: string;
+};
+
+let mermaidInitialized = false;
+
+const enhanceCodeBlocks = async (root: HTMLElement) => {
+  const blocks = root.querySelectorAll('pre code.language-mermaid, pre code[class*="mermaid"]');
+  if (blocks.length === 0) return;
+
+  const mermaid = (await import('mermaid')).default;
+  if (!mermaidInitialized) {
+    mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+    mermaidInitialized = true;
+  }
+
+  await Promise.all(
+    Array.from(blocks).map(async (block, index) => {
+      const source = block.textContent?.trim();
+      if (!source) return;
+      try {
+        const id = `post-mermaid-${index}-${Date.now()}`;
+        const { svg } = await mermaid.render(id, source);
+        const pre = block.closest('pre');
+        if (pre) {
+          pre.outerHTML = `<div class="mermaid-diagram my-4 overflow-x-auto">${svg}</div>`;
+        }
+      } catch {
+        // 원본 코드 블록 유지
+      }
+    }),
+  );
+};
+
+/**
+ * 읽기 전용 HTML 본문 렌더러.
+ * Novel/TipTap 런타임 없이 서버에서 내려준 HTML을 바로 표시해 JS 비용을 줄인다.
+ */
+export default function PostHtmlViewer({ content }: PostHtmlViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const html = content ? preprocessHTML(content) : '';
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    void enhanceCodeBlocks(containerRef.current);
+  }, [html]);
+
+  return (
+    <div className='blog-prose'>
+      <div
+        ref={containerRef}
+        className='ProseMirror'
+        // 관리자 작성 HTML — XSS는 관리자 권한 콘텐츠로 제한됨
+        dangerouslySetInnerHTML={{ __html: typeof html === 'string' ? html : '' }}
+      />
+    </div>
+  );
+}

--- a/src/shared/ui/TextEditor/code-block.tsx
+++ b/src/shared/ui/TextEditor/code-block.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
 import { useSession } from 'next-auth/react';
+import { useEffect, useRef } from 'react';
 
 let mermaidInitialized = false;
 
@@ -65,7 +65,9 @@ export default function CodeBlock(props: any) {
           previewer.current.innerHTML = svg;
         }
       } catch (error) {
-        console.error('Mermaid rendering error:', error);
+        if (process.env.NODE_ENV === 'development') {
+          console.error('Mermaid rendering error:', error);
+        }
         if (!cancelled && previewer.current) {
           const message = error instanceof Error ? error.message : 'Unknown error';
           previewer.current.innerHTML = `<div style="color: red; padding: 1rem;">Mermaid 구문 오류: ${message}</div>`;

--- a/src/shared/ui/TextEditor/code-block.tsx
+++ b/src/shared/ui/TextEditor/code-block.tsx
@@ -1,23 +1,31 @@
 import { useEffect, useRef } from 'react';
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
-import mermaid from 'mermaid';
 import { useSession } from 'next-auth/react';
 
-mermaid.initialize({
-  startOnLoad: false,
-  theme: 'dark',
-  themeVariables: {
-    primaryColor: '#00ff88',
-    primaryTextColor: '#ffffff',
-    primaryBorderColor: '#00ff88',
-    lineColor: '#00ff88',
-    sectionBkgColor: '#1a1a1a',
-    altSectionBkgColor: '#2a2a2a',
-    gridColor: '#333333',
-    secondaryColor: '#333333',
-    tertiaryColor: '#444444',
-  },
-});
+let mermaidInitialized = false;
+
+const ensureMermaid = async () => {
+  const mermaid = (await import('mermaid')).default;
+  if (!mermaidInitialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'dark',
+      themeVariables: {
+        primaryColor: '#00ff88',
+        primaryTextColor: '#ffffff',
+        primaryBorderColor: '#00ff88',
+        lineColor: '#00ff88',
+        sectionBkgColor: '#1a1a1a',
+        altSectionBkgColor: '#2a2a2a',
+        gridColor: '#333333',
+        secondaryColor: '#333333',
+        tertiaryColor: '#444444',
+      },
+    });
+    mermaidInitialized = true;
+  }
+  return mermaid;
+};
 
 export enum Mode {
   Preview = 0,
@@ -36,32 +44,40 @@ export default function CodeBlock(props: any) {
   const isMermaid = defaultLanguage === 'mermaid';
 
   useEffect(() => {
-    if (mode === Mode.Preview && previewer.current && isMermaid && textContent.trim()) {
-      try {
-        const id = `mermaid-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    if (mode !== Mode.Preview || !previewer.current || !isMermaid || !textContent.trim()) {
+      return;
+    }
 
-        // HTML 엔티티 디코딩
+    let cancelled = false;
+
+    const renderMermaid = async () => {
+      try {
+        const mermaid = await ensureMermaid();
+        if (cancelled || !previewer.current) return;
+
+        const id = `mermaid-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
         const textarea = document.createElement('textarea');
         textarea.innerHTML = textContent;
         const decodedTextContent = textarea.value;
 
-        mermaid
-          .render(id, decodedTextContent)
-          .then(({ svg }) => {
-            if (previewer.current) {
-              previewer.current.innerHTML = svg;
-            }
-          })
-          .catch((error) => {
-            console.error('Mermaid rendering error:', error);
-            if (previewer.current) {
-              previewer.current.innerHTML = `<div style="color: red; padding: 1rem;">Mermaid 구문 오류: ${error.message}</div>`;
-            }
-          });
-      } catch (e) {
-        console.log(e);
+        const { svg } = await mermaid.render(id, decodedTextContent);
+        if (!cancelled && previewer.current) {
+          previewer.current.innerHTML = svg;
+        }
+      } catch (error) {
+        console.error('Mermaid rendering error:', error);
+        if (!cancelled && previewer.current) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          previewer.current.innerHTML = `<div style="color: red; padding: 1rem;">Mermaid 구문 오류: ${message}</div>`;
+        }
       }
-    }
+    };
+
+    void renderMermaid();
+
+    return () => {
+      cancelled = true;
+    };
   }, [mode, textContent, isMermaid]);
 
   return (

--- a/src/shared/ui/TextEditor/viewerExtensions.ts
+++ b/src/shared/ui/TextEditor/viewerExtensions.ts
@@ -1,0 +1,161 @@
+import {
+  CodeBlockLowlight,
+  Color,
+  HighlightExtension,
+  HorizontalRule,
+  Mathematics,
+  StarterKit,
+  TaskItem,
+  TaskList,
+  TextStyle,
+  TiptapImage,
+  TiptapLink,
+  TiptapUnderline,
+  UpdatedImage,
+  Youtube,
+} from 'novel/extensions';
+import { TableKit } from '@tiptap/extension-table';
+import { cx } from 'class-variance-authority';
+import { common, createLowlight } from 'lowlight';
+
+const tiptapLink = TiptapLink.configure({
+  HTMLAttributes: {
+    class: cx(
+      'text-muted-foreground underline underline-offset-[3px] hover:text-primary transition-colors cursor-pointer',
+    ),
+  },
+});
+
+const updatedImage = UpdatedImage.configure({
+  HTMLAttributes: {
+    class: cx('rounded-lg border border-muted'),
+  },
+});
+
+const tiptapImage = TiptapImage.configure({
+  allowBase64: true,
+  HTMLAttributes: {
+    class: cx('rounded-lg border border-muted'),
+  },
+});
+
+const taskList = TaskList.configure({
+  HTMLAttributes: {
+    class: cx('not-prose pl-2 '),
+  },
+});
+
+const taskItem = TaskItem.configure({
+  HTMLAttributes: {
+    class: cx('flex gap-2 items-start my-4'),
+  },
+  nested: true,
+});
+
+const horizontalRule = HorizontalRule.configure({
+  HTMLAttributes: {
+    class: cx('mt-4 mb-6 border-t border-muted-foreground'),
+  },
+});
+
+const starterKit = StarterKit.configure({
+  bulletList: {
+    HTMLAttributes: {
+      class: cx('list-disc list-outside leading-3 -mt-2'),
+    },
+  },
+  orderedList: {
+    HTMLAttributes: {
+      class: cx('list-decimal list-outside leading-3 -mt-2'),
+    },
+  },
+  listItem: {
+    HTMLAttributes: {
+      class: cx('leading-normal -mb-2'),
+    },
+  },
+  blockquote: {
+    HTMLAttributes: {
+      class: cx('border-l-4 border-primary'),
+    },
+  },
+  codeBlock: false,
+  code: {
+    HTMLAttributes: {
+      class: cx('rounded-md bg-gray-800 px-1.5 py-1 font-mono font-medium'),
+      spellcheck: 'false',
+    },
+  },
+  horizontalRule: false,
+  dropcursor: false,
+  gapcursor: false,
+});
+
+const lowlight = createLowlight(common);
+
+const codeBlockLowlight = CodeBlockLowlight.configure({
+  lowlight,
+  HTMLAttributes: {
+    class: cx('rounded-md bg-muted text-muted-foreground border p-5 font-mono font-medium'),
+  },
+});
+
+const youtube = Youtube.configure({
+  HTMLAttributes: {
+    class: cx('rounded-lg border border-muted'),
+  },
+  inline: false,
+});
+
+const mathematics = Mathematics.configure({
+  HTMLAttributes: {
+    class: cx('text-foreground rounded p-1 hover:bg-accent cursor-pointer'),
+  },
+  katexOptions: {
+    throwOnError: false,
+  },
+});
+
+const tableKit = TableKit.configure({
+  table: {
+    HTMLAttributes: {
+      class: cx('border-collapse border-2 border-gray-500 dark:border-gray-400 my-6 w-full'),
+    },
+  },
+  tableRow: {
+    HTMLAttributes: {
+      class: cx('border-b border-gray-400 dark:border-gray-500'),
+    },
+  },
+  tableHeader: {
+    HTMLAttributes: {
+      class: cx(
+        'border border-gray-500 dark:border-gray-400 bg-gray-700 px-4 py-3 text-left font-semibold text-foreground',
+      ),
+    },
+  },
+  tableCell: {
+    HTMLAttributes: {
+      class: cx('border border-gray-500 dark:border-gray-400 px-4 py-3 text-foreground'),
+    },
+  },
+});
+
+/** 읽기 전용 뷰어용 — 드래그/업로드/AI/머메이드 노드뷰 등 편집기 전용 확장 제외 */
+export const viewerExtensions = [
+  starterKit,
+  tiptapLink,
+  tiptapImage,
+  updatedImage,
+  taskList,
+  taskItem,
+  horizontalRule,
+  codeBlockLowlight,
+  youtube,
+  mathematics,
+  TiptapUnderline,
+  tableKit,
+  HighlightExtension,
+  TextStyle,
+  Color,
+];

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,15 +1,14 @@
+/**
+ * 경량 UI만 배럴로 노출합니다.
+ * Three.js / Novel / 에디터 등 무거운 모듈은 직접 경로로 import 하세요.
+ * (배럴을 통한 side-effect preload가 블로그 라우트에 3D 에셋을 끌어오던 문제 방지)
+ */
 export * from './Meteors';
 export * from './AuthSidebar';
-export * from './Loader';
 export * from './modal';
 export * from './Navbar';
-export * from './NovelViewer';
 export * from './Tag';
 export * from './VisitorLogger';
-export * from './AnimatedText';
-export * from './WatchRobot';
-export * from './HelloBot';
-export * from './MoveBot';
 export * from './FloatingActionButton';
 export { Dropdown } from './Dropdown';
 export { Button } from './Button';

--- a/src/shared/utils/__tests__/sanitize-html.test.ts
+++ b/src/shared/utils/__tests__/sanitize-html.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { sanitizePostHtml } from '../sanitize-html';
+
+describe('sanitizePostHtml', () => {
+  test('허용된 Tiptap 태그는 유지한다', () => {
+    const html = '<h2>제목</h2><p>본문 <strong>강조</strong>와 <a href="https://example.com">링크</a></p>';
+    expect(sanitizePostHtml(html)).toContain('<h2>제목</h2>');
+    expect(sanitizePostHtml(html)).toContain('<strong>강조</strong>');
+    expect(sanitizePostHtml(html)).toContain('href="https://example.com"');
+  });
+
+  test('script와 event handler를 제거한다', () => {
+    const html = '<p onclick="alert(1)">ok</p><script>alert(2)</script><img src="x" onerror="alert(3)">';
+    const sanitized = sanitizePostHtml(html);
+    expect(sanitized).not.toMatch(/script/i);
+    expect(sanitized).not.toMatch(/onclick/i);
+    expect(sanitized).not.toMatch(/onerror/i);
+    expect(sanitized).toContain('ok');
+  });
+
+  test('javascript: URL을 제거한다', () => {
+    const html = '<a href="javascript:alert(1)">click</a>';
+    const sanitized = sanitizePostHtml(html);
+    expect(sanitized.toLowerCase()).not.toContain('javascript:');
+  });
+
+  test('YouTube iframe만 허용한다', () => {
+    const allowed = sanitizePostHtml(
+      '<iframe src="https://www.youtube.com/embed/abc123" allowfullscreen></iframe>',
+    );
+    expect(allowed).toContain('youtube.com/embed/abc123');
+
+    const blocked = sanitizePostHtml('<iframe src="https://evil.example/embed"></iframe>');
+    expect(blocked).not.toContain('evil.example');
+  });
+});

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './create-slug';
 export * from './formateDate';
 export * from './process-html';
+export * from './sanitize-html';

--- a/src/shared/utils/sanitize-html.ts
+++ b/src/shared/utils/sanitize-html.ts
@@ -1,0 +1,138 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+const TIPTAP_TAGS = [
+  'p',
+  'br',
+  'hr',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  's',
+  'del',
+  'code',
+  'pre',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'a',
+  'img',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+  'colgroup',
+  'col',
+  'span',
+  'mark',
+  'div',
+  'sub',
+  'sup',
+  'iframe',
+  'input',
+  'label',
+];
+
+const TIPTAP_ATTR = [
+  'href',
+  'target',
+  'rel',
+  'class',
+  'id',
+  'src',
+  'alt',
+  'title',
+  'width',
+  'height',
+  'colspan',
+  'rowspan',
+  'style',
+  'spellcheck',
+  'type',
+  'checked',
+  'disabled',
+  'allow',
+  'allowfullscreen',
+  'frameborder',
+  'loading',
+  'referrerpolicy',
+  'data-type',
+  'data-checked',
+  'data-language',
+  'data-mode',
+  'data-youtube-video',
+];
+
+const ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|tel):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$)|data:image\/)/i;
+
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com']);
+
+let hooksRegistered = false;
+
+const registerHooks = () => {
+  if (hooksRegistered) return;
+  hooksRegistered = true;
+
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A') {
+      node.setAttribute('rel', 'noopener noreferrer nofollow');
+      const href = node.getAttribute('href');
+      if (href?.toLowerCase().startsWith('javascript:')) {
+        node.removeAttribute('href');
+      }
+    }
+
+    if (node.tagName === 'IFRAME') {
+      const src = node.getAttribute('src');
+      if (!src) {
+        node.parentNode?.removeChild(node);
+        return;
+      }
+      try {
+        const url = new URL(src, 'https://invalid.local');
+        if (!YOUTUBE_HOSTS.has(url.hostname)) {
+          node.parentNode?.removeChild(node);
+        }
+      } catch {
+        node.parentNode?.removeChild(node);
+      }
+    }
+  });
+};
+
+/**
+ * Tiptap/Novel 본문에 필요한 태그만 남기고 event handler·위험 scheme을 제거한다.
+ */
+export const sanitizePostHtml = (html: string) => {
+  if (!html) return '';
+
+  registerHooks();
+
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: TIPTAP_TAGS,
+    ALLOWED_ATTR: TIPTAP_ATTR,
+    ALLOW_DATA_ATTR: true,
+    ALLOWED_URI_REGEXP,
+    FORBID_TAGS: ['script', 'object', 'embed', 'form', 'style'],
+    FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
+  });
+};
+
+/** Mermaid 등 SVG 조각을 렌더하기 전에 script를 제거한다. */
+export const sanitizeSvgHtml = (html: string) => {
+  if (!html) return '';
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { svg: true, svgFilters: true, html: true },
+    FORBID_TAGS: ['script', 'foreignObject'],
+  });
+};

--- a/src/views/home/HomeCanvas.tsx
+++ b/src/views/home/HomeCanvas.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { useFBX, useGLTF } from '@react-three/drei';
+import { useFBX, useGLTF, useTexture } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import * as three from 'three';
 import { PORTFOLIO_PORTAL_SESSION_KEY } from '@/entities/portfolio/model/cinematic-transition';
-import { CanvasLoader } from '@/shared/ui';
-import { PortalDiscoveryOverlay, PortalEnterTransition } from '@/widgets/home';
+import { CanvasLoader } from '@/shared/ui/Loader';
 import type { CosmosPortalId } from '@/widgets/home/model/cosmos-portals';
 import { CinematicCosmosScene, type CosmosSceneTheme } from '@/widgets/home/ui/CinematicCosmosScene';
+import { PortalDiscoveryOverlay } from '@/widgets/home/ui/PortalDiscoveryOverlay';
+import { PortalEnterTransition } from '@/widgets/home/ui/PortalEnterTransition';
 
 export const HomeCanvas = () => {
   const router = useRouter();
@@ -24,6 +25,11 @@ export const HomeCanvas = () => {
       useGLTF.preload('/WalkingAstro.glb');
       useFBX.preload('/snp.fbx');
       useFBX.preload('/Typing.fbx');
+      useTexture.preload('/cosmos/textures/dark_rock_diff_2k.jpg');
+      useTexture.preload('/cosmos/textures/dark_rock_nor_2k.jpg');
+      useTexture.preload('/cosmos/textures/dark_rock_rough_2k.jpg');
+      useTexture.preload('/cosmos/textures/earth_black_marble.jpg');
+      useTexture.preload('/cosmos/textures/earth_day_hq.jpg');
     }, 100);
 
     return () => {

--- a/src/widgets/home/index.ts
+++ b/src/widgets/home/index.ts
@@ -1,1 +1,6 @@
-export * from './ui';
+/**
+ * 홈 위젯 public API.
+ * CosmosCursor / 3D 씬은 side-effect preload가 있으므로 필요 시 직접 경로로 import 하세요.
+ */
+export { PortalDiscoveryOverlay } from './ui/PortalDiscoveryOverlay';
+export { PortalEnterTransition } from './ui/PortalEnterTransition';

--- a/src/widgets/home/ui/CinematicCosmosScene.tsx
+++ b/src/widgets/home/ui/CinematicCosmosScene.tsx
@@ -1276,11 +1276,4 @@ export const CinematicCosmosScene = ({
   );
 };
 
-for (const path of ROCK_PATHS) {
-  useGLTF.preload(path);
-}
-useTexture.preload('/cosmos/textures/dark_rock_diff_2k.jpg');
-useTexture.preload('/cosmos/textures/dark_rock_nor_2k.jpg');
-useTexture.preload('/cosmos/textures/dark_rock_rough_2k.jpg');
-useTexture.preload('/cosmos/textures/earth_black_marble.jpg');
-useTexture.preload('/cosmos/textures/earth_day_hq.jpg');
+// 텍스처/록 모델 preload는 홈 씬 마운트 경로(HomeCanvas)에서만 수행

--- a/src/widgets/home/ui/WalkingAvatar.tsx
+++ b/src/widgets/home/ui/WalkingAvatar.tsx
@@ -116,9 +116,7 @@ type WalkingAvatarProps = ComponentProps<'group'> & {
   locked?: boolean;
 };
 
-useGLTF.preload('/WalkingAstro.glb');
-useFBX.preload('/snp.fbx');
-useFBX.preload('/Typing.fbx');
+// preload는 HomeCanvas에서 홈 진입 시에만 수행
 
 export function WalkingAvatar({
   triggerSnp,

--- a/src/widgets/post/ui/BlogHeader.tsx
+++ b/src/widgets/post/ui/BlogHeader.tsx
@@ -34,9 +34,6 @@ export default function BlogHeader() {
     <>
       <motion.div
         className={`relative mx-auto mb-8 hidden h-16 w-full max-w-4xl items-center justify-between rounded-xl p-4 lg:flex ${blogTheme.chromeBar}`}
-        initial={{ y: -16, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.4 }}
       >
         <span className={blogTheme.chromeShine} aria-hidden />
         <div className='flex items-center'>
@@ -122,74 +119,75 @@ export default function BlogHeader() {
           transition={{ duration: 0.4 }}
         >
           <span className={blogTheme.chromeShine} aria-hidden />
-          <div className='absolute left-3 top-3'>
-            <Dropdown
-              placement='bottom-left'
-              contentClassName={`min-w-[100px] ${blogTheme.dropdown}`}
-              trigger={({ ref, onClick }) => (
-                <button
-                  ref={ref as React.RefObject<HTMLButtonElement>}
-                  type='button'
-                  onClick={onClick}
-                  className={`rounded-lg p-2 ${blogTheme.navBtn}`}
-                  title='페이지 이동'
-                >
-                  <Navigation size={14} className={blogTheme.textAccent} />
-                </button>
-              )}
-            >
-              <button
-                type='button'
-                onClick={() => handleNavigation('/')}
-                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
+          <div className='relative flex h-10 items-center gap-2'>
+            <div className='flex shrink-0 items-center'>
+              <Dropdown
+                placement='bottom-left'
+                contentClassName={`min-w-[100px] ${blogTheme.dropdown}`}
+                trigger={({ ref, onClick }) => (
+                  <button
+                    ref={ref as React.RefObject<HTMLButtonElement>}
+                    type='button'
+                    onClick={onClick}
+                    className={`rounded-lg p-2 ${blogTheme.navBtn}`}
+                    title='페이지 이동'
+                    aria-label='페이지 이동'
+                  >
+                    <Navigation size={14} className={blogTheme.textAccent} />
+                  </button>
+                )}
               >
-                <Globe size={12} />
-                Home
-              </button>
-              <button
-                type='button'
-                onClick={() => handleNavigation('/blog')}
-                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
-              >
-                <Home size={12} />
-                Blog
-              </button>
-              {isAuthenticated ? (
                 <button
                   type='button'
-                  onClick={handleLogout}
-                  className='flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-500/10'
-                >
-                  <LogOut size={12} />
-                  Logout
-                </button>
-              ) : (
-                <button
-                  type='button'
-                  onClick={() => handleNavigation('/login')}
+                  onClick={() => handleNavigation('/')}
                   className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
                 >
-                  <User size={12} />
-                  Login
+                  <Globe size={12} />
+                  Home
                 </button>
-              )}
-            </Dropdown>
-          </div>
+                <button
+                  type='button'
+                  onClick={() => handleNavigation('/blog')}
+                  className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
+                >
+                  <Home size={12} />
+                  Blog
+                </button>
+                {isAuthenticated ? (
+                  <button
+                    type='button'
+                    onClick={handleLogout}
+                    className='flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-500/10'
+                  >
+                    <LogOut size={12} />
+                    Logout
+                  </button>
+                ) : (
+                  <button
+                    type='button'
+                    onClick={() => handleNavigation('/login')}
+                    className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-xs ${blogTheme.dropdownItem}`}
+                  >
+                    <User size={12} />
+                    Login
+                  </button>
+                )}
+              </Dropdown>
+            </div>
 
-          <div className='relative flex h-10 items-center justify-center px-12'>
             <button
               type='button'
               onClick={() => handleNavigation('/blog')}
               aria-label='블로그 홈으로 이동'
-              className='flex items-center gap-2 border-none bg-transparent p-0 text-base font-semibold'
+              className='flex min-w-0 flex-1 items-center justify-center gap-1.5 border-none bg-transparent p-0 text-sm font-semibold sm:gap-2 sm:text-base'
               style={syne}
             >
-              <Image src='/logo.png' alt='logo' width={22} height={22} />
-              <span className={blogTheme.titleGradient}>3D Tech Blog</span>
+              <Image src='/logo.png' alt='logo' width={20} height={20} className='shrink-0' />
+              <span className={`truncate ${blogTheme.titleGradient}`}>3D Tech Blog</span>
             </button>
 
-            <div className='absolute right-0 top-0 flex items-center gap-2'>
-              <ThemeToggleButton variant='blog' className='h-8 w-8' />
+            <div className='flex shrink-0 items-center gap-1 sm:gap-2'>
+              <ThemeToggleButton variant='blog' className='h-8 w-8 shrink-0' />
               <BlogSearch />
               <button
                 type='button'

--- a/src/widgets/post/ui/BlogLandingScene.tsx
+++ b/src/widgets/post/ui/BlogLandingScene.tsx
@@ -1,19 +1,19 @@
 'use client';
 
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { Suspense, useEffect, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { Bloom, EffectComposer } from '@react-three/postprocessing';
 import { MeshReflectorMaterial } from '@react-three/drei';
-import { Macintosh } from '@/widgets/post/ui/Macintosh';
-import { ComputerBackground } from '@/widgets/post/ui/ComputerBackground';
-import { CanvasLoader } from '@/shared/ui/Loader';
-import { AnimatedText } from '@/shared/ui/AnimatedText';
-import { WatchRobot } from '@/shared/ui/WatchRobot';
-import { HelloBot } from '@/shared/ui/HelloBot';
-import { MoveBot } from '@/shared/ui/MoveBot';
-import { FloatingActionButton } from '@/shared/ui/FloatingActionButton';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Bloom, EffectComposer } from '@react-three/postprocessing';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { AnimatedText } from '@/shared/ui/AnimatedText';
+import { FloatingActionButton } from '@/shared/ui/FloatingActionButton';
+import { HelloBot } from '@/shared/ui/HelloBot';
+import { CanvasLoader } from '@/shared/ui/Loader';
+import { MoveBot } from '@/shared/ui/MoveBot';
+import { WatchRobot } from '@/shared/ui/WatchRobot';
+import { ComputerBackground } from '@/widgets/post/ui/ComputerBackground';
+import { Macintosh } from '@/widgets/post/ui/Macintosh';
 
 function AnimatedCamera({ cameraPos }: { cameraPos: { x: number; y: number; z: number } }) {
   const { camera } = useThree();
@@ -30,6 +30,7 @@ const BlogLandingScene = () => {
   const [htmlOpacity, setHtmlOpacity] = useState(1);
   const [isNavigating, setIsNavigating] = useState(false);
   const [enableEffects, setEnableEffects] = useState(false);
+  const navigateTimeoutRef = useRef<number | null>(null);
 
   const handleWheel = (e: React.WheelEvent) => {
     if (!isNavigating) {
@@ -51,13 +52,23 @@ const BlogLandingScene = () => {
   }, [htmlScale]);
 
   useEffect(() => {
-    if (!isNavigating && htmlScale >= 8) {
-      setIsNavigating(true);
-      setTimeout(() => {
-        router.push('/blog/all');
-      }, 300);
+    if (htmlScale < 8 || navigateTimeoutRef.current != null) {
+      return;
     }
-  }, [htmlScale, isNavigating, router]);
+
+    setIsNavigating(true);
+    navigateTimeoutRef.current = window.setTimeout(() => {
+      router.push('/blog/all');
+    }, 300);
+  }, [htmlScale, router]);
+
+  useEffect(() => {
+    return () => {
+      if (navigateTimeoutRef.current != null) {
+        window.clearTimeout(navigateTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const connection = (navigator as Navigator & { connection?: { saveData?: boolean; effectiveType?: string } })
@@ -89,14 +100,7 @@ const BlogLandingScene = () => {
           >
             <color attach='background' args={['black']} />
             <hemisphereLight intensity={0.15} groundColor='black' />
-            <spotLight
-              decay={0}
-              position={[10, 20, 10]}
-              angle={0.12}
-              penumbra={1}
-              intensity={1}
-              castShadow={false}
-            />
+            <spotLight decay={0} position={[10, 20, 10]} angle={0.12} penumbra={1} intensity={1} castShadow={false} />
             <Suspense fallback={<CanvasLoader />}>
               <Macintosh
                 scale={0.25}

--- a/src/widgets/post/ui/BlogLandingScene.tsx
+++ b/src/widgets/post/ui/BlogLandingScene.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Suspense, useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Bloom, EffectComposer } from '@react-three/postprocessing';
+import { MeshReflectorMaterial } from '@react-three/drei';
+import { Macintosh } from '@/widgets/post/ui/Macintosh';
+import { ComputerBackground } from '@/widgets/post/ui/ComputerBackground';
+import { CanvasLoader } from '@/shared/ui/Loader';
+import { AnimatedText } from '@/shared/ui/AnimatedText';
+import { WatchRobot } from '@/shared/ui/WatchRobot';
+import { HelloBot } from '@/shared/ui/HelloBot';
+import { MoveBot } from '@/shared/ui/MoveBot';
+import { FloatingActionButton } from '@/shared/ui/FloatingActionButton';
+import { useRouter } from 'next/navigation';
+
+function AnimatedCamera({ cameraPos }: { cameraPos: { x: number; y: number; z: number } }) {
+  const { camera } = useThree();
+  useFrame(() => {
+    camera.position.set(cameraPos.x, cameraPos.y, cameraPos.z);
+    camera.updateProjectionMatrix();
+  });
+  return null;
+}
+
+const BlogLandingScene = () => {
+  const router = useRouter();
+  const [htmlScale, setHtmlScale] = useState(1);
+  const [htmlOpacity, setHtmlOpacity] = useState(1);
+  const [isNavigating, setIsNavigating] = useState(false);
+  const [enableEffects, setEnableEffects] = useState(false);
+
+  const handleWheel = (e: React.WheelEvent) => {
+    if (!isNavigating) {
+      setHtmlScale((prev) => {
+        let next = prev + e.deltaY * 0.01;
+        if (next < 1) {
+          next = 1;
+        }
+        if (next > 8) {
+          next = 8;
+        }
+        return next;
+      });
+    }
+  };
+
+  useEffect(() => {
+    setHtmlOpacity(1 - (htmlScale - 1) / 8);
+  }, [htmlScale]);
+
+  useEffect(() => {
+    if (!isNavigating && htmlScale >= 8) {
+      setIsNavigating(true);
+      setTimeout(() => {
+        router.push('/blog/all');
+      }, 300);
+    }
+  }, [htmlScale, isNavigating, router]);
+
+  useEffect(() => {
+    const connection = (navigator as Navigator & { connection?: { saveData?: boolean; effectiveType?: string } })
+      .connection;
+    const saveData = Boolean(connection?.saveData);
+    const slowNetwork = connection?.effectiveType === '2g' || connection?.effectiveType === 'slow-2g';
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const lowMemory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+    const shouldEnableEffects = !saveData && !slowNetwork && !reducedMotion && (lowMemory == null || lowMemory >= 4);
+    setEnableEffects(shouldEnableEffects);
+  }, []);
+
+  return (
+    <main className='fixed inset-0 z-10 h-full w-full bg-gray-700' onWheel={handleWheel} style={{ overflow: 'hidden' }}>
+      <AnimatePresence>
+        <motion.div
+          key='mac-canvas'
+          initial={{ opacity: 0, scale: 1 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0, y: 700 }}
+          transition={{ duration: 0.6, ease: 'easeInOut' }}
+          className='h-full w-full'
+        >
+          <Canvas
+            dpr={[1, 1.25]}
+            performance={{ min: 0.5 }}
+            camera={{ fov: 70, near: 1, zoom: 15, position: [-0.2, 1.5, 8.88] }}
+            eventPrefix='client'
+          >
+            <color attach='background' args={['black']} />
+            <hemisphereLight intensity={0.15} groundColor='black' />
+            <spotLight
+              decay={0}
+              position={[10, 20, 10]}
+              angle={0.12}
+              penumbra={1}
+              intensity={1}
+              castShadow={false}
+            />
+            <Suspense fallback={<CanvasLoader />}>
+              <Macintosh
+                scale={0.25}
+                htmlScale={htmlScale}
+                htmlOpacity={htmlOpacity}
+                showFullPage={false}
+                position={[-0.08, 0.08, 0]}
+                rotation={[0, Math.PI / 6, 0]}
+              />
+              <ComputerBackground scale={0.11} position={[0, 0.001, 0]} />
+              <AnimatedText />
+              <WatchRobot scale={0.002} position={[0.1, 0.12, 0.3]} rotation={[0, -Math.PI / 1.5, 0]} />
+              <HelloBot scale={0.06} position={[0.18, 0.18, -0.16]} rotation={[0, -Math.PI / 4, 0]} />
+              <MoveBot scale={0.05} position={[0.4, 0, 0.7]} rotation={[0, -Math.PI / 4, 0]} />
+              <AnimatedCamera cameraPos={{ x: -0.16, y: 1.4, z: 7.5 }} />
+              <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
+                <planeGeometry args={[50, 50]} />
+                <MeshReflectorMaterial
+                  blur={enableEffects ? [200, 20] : [0, 0]}
+                  resolution={enableEffects ? 512 : 256}
+                  mixBlur={1}
+                  mixStrength={enableEffects ? 120 : 40}
+                  roughness={1}
+                  depthScale={1.2}
+                  minDepthThreshold={0.4}
+                  maxDepthThreshold={1.4}
+                  color='#202020'
+                  metalness={0.8}
+                />
+              </mesh>
+              {enableEffects ? (
+                <EffectComposer enableNormalPass={false} multisampling={0}>
+                  <Bloom luminanceThreshold={0.2} mipmapBlur luminanceSmoothing={0.1} intensity={2.5} />
+                </EffectComposer>
+              ) : null}
+            </Suspense>
+          </Canvas>
+          <FloatingActionButton />
+
+          <div className='absolute bottom-8 left-1/2 -translate-x-1/2 transform text-center text-white'>
+            <div className='animate-pulse duration-[3000ms]'>
+              <p className='mb-2 text-sm opacity-80'>스크롤하여 블로그 보기</p>
+              <div className='relative mx-auto h-10 w-6 rounded-full border-2 border-white/70'>
+                <div
+                  className='mx-auto mt-2 h-3 w-1 translate-y-0 transform animate-bounce rounded-full bg-white duration-[2500ms]'
+                  style={{ animationTimingFunction: 'cubic-bezier(0.4, 0, 0.6, 1)' }}
+                />
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </main>
+  );
+};
+
+export default BlogLandingScene;

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -1,15 +1,22 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { usePost } from '@/features/post/model';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
+import { getPostList } from '@/features/post/api/post-api';
+import type { GetPostListParams, GetPostListResponse } from '@/features/post/model';
 import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
-import { RecentPosts } from './RecentPosts';
-import { PostList } from './PostList';
-import { NoResults } from './NoResults';
+import { queryKeys } from '@/shared/queryKeys';
 import { BlogSectionTitle } from './BlogSectionTitle';
+import { NoResults } from './NoResults';
+import { PostList } from './PostList';
+import { RecentPosts } from './RecentPosts';
 
-export const BlogMainPage = () => {
+type BlogMainPageProps = {
+  initialPosts?: GetPostListResponse;
+};
+
+export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
   const searchParams = useSearchParams();
   const search = searchParams.get('search') ?? '';
   const category = searchParams.get('category') ?? '';
@@ -17,19 +24,44 @@ export const BlogMainPage = () => {
   const tags = tagsParam.split(',').filter(Boolean);
   const hasFilters = Boolean(search || category || tags.length > 0);
 
-  const { posts, isLoading } = usePost({
+  const listParams: GetPostListParams = {
     search,
     category,
     tags: tagsParam,
     page: 1,
     limit: 10,
+  };
+
+  const canUseInitialData = Boolean(initialPosts) && !hasFilters;
+
+  const { data, isLoading } = useInfiniteQuery<GetPostListResponse>({
+    queryKey: queryKeys.post.all(listParams).queryKey,
+    queryFn: ({ pageParam = 1 }) => getPostList({ ...listParams, page: pageParam as number }),
+    initialPageParam: 1,
+    staleTime: 60_000,
+    initialData: canUseInitialData
+      ? {
+          pages: [initialPosts as GetPostListResponse],
+          pageParams: [1],
+        }
+      : undefined,
+    getNextPageParam: (lastPage) => {
+      const currentPage = lastPage.meta?.pagination?.currentPage;
+      const hasNextPage = lastPage.meta?.pagination?.hasNextPage;
+      if (hasNextPage && currentPage) {
+        return currentPage + 1;
+      }
+      return undefined;
+    },
+    placeholderData: keepPreviousData,
   });
 
-  const postsData = posts?.pages?.flatMap((page) => page.data ?? []) ?? [];
+  const postsData = data?.pages?.flatMap((page) => page.data ?? []) ?? [];
+  const showLoading = isLoading && postsData.length === 0;
   const trackedKeyRef = useRef<string>('');
 
   useEffect(() => {
-    if (isLoading || !hasFilters) return;
+    if (showLoading || !hasFilters) return;
 
     const key = `${search}|${category}|${tagsParam}|${postsData.length}`;
     if (trackedKeyRef.current === key) return;
@@ -53,9 +85,9 @@ export const BlogMainPage = () => {
         tag_count: tags.length,
       });
     }
-  }, [isLoading, hasFilters, search, category, tagsParam, tags.length, postsData.length]);
+  }, [showLoading, hasFilters, search, category, tagsParam, tags.length, postsData.length]);
 
-  if (!isLoading && postsData.length === 0) {
+  if (!showLoading && postsData.length === 0) {
     return (
       <div className='mx-auto w-full max-w-4xl'>
         <NoResults
@@ -79,7 +111,7 @@ export const BlogMainPage = () => {
     return (
       <div className='mx-auto w-full max-w-4xl'>
         <BlogSectionTitle subtitle={filterLabel || '조건에 맞는 글'}>검색 결과</BlogSectionTitle>
-        <PostList posts={postsData} isLoading={isLoading} />
+        <PostList posts={postsData} isLoading={showLoading} />
       </div>
     );
   }
@@ -90,12 +122,12 @@ export const BlogMainPage = () => {
   return (
     <div className='mx-auto w-full max-w-4xl'>
       <BlogSectionTitle subtitle='최근에 올라온 글'>Recent</BlogSectionTitle>
-      <RecentPosts posts={recentPosts} isLoading={isLoading} />
+      <RecentPosts posts={recentPosts} isLoading={showLoading} />
 
       {restPosts.length > 0 && (
         <>
           <BlogSectionTitle subtitle='더 많은 이야기'>Archive</BlogSectionTitle>
-          <PostList posts={restPosts} isLoading={isLoading} />
+          <PostList posts={restPosts} isLoading={showLoading} />
         </>
       )}
     </div>

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
 import { getPostList } from '@/features/post/api/post-api';
 import type { GetPostListParams, GetPostListResponse } from '@/features/post/model';
 import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
 import { queryKeys } from '@/shared/queryKeys';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { BlogSectionTitle } from './BlogSectionTitle';
 import { NoResults } from './NoResults';
 import { PostList } from './PostList';
@@ -14,6 +15,53 @@ import { RecentPosts } from './RecentPosts';
 
 type BlogMainPageProps = {
   initialPosts?: GetPostListResponse;
+};
+
+type LoadMorePostsProps = {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+};
+
+const LoadMorePosts = ({ hasNextPage, isFetchingNextPage, onLoadMore }: LoadMorePostsProps) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!hasNextPage) return;
+
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+          onLoadMore();
+        }
+      },
+      { rootMargin: '240px' },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  if (!hasNextPage && !isFetchingNextPage) {
+    return null;
+  }
+
+  return (
+    <div ref={sentinelRef} className='mt-8 flex justify-center'>
+      <button
+        type='button'
+        onClick={onLoadMore}
+        disabled={isFetchingNextPage || !hasNextPage}
+        className={`rounded-lg px-4 py-2 text-sm transition disabled:opacity-60 ${blogTheme.navBtn}`}
+        aria-label='다음 글 불러오기'
+      >
+        {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
+      </button>
+    </div>
+  );
 };
 
 export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
@@ -34,7 +82,8 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
 
   const canUseInitialData = Boolean(initialPosts) && !hasFilters;
 
-  const { data, isLoading } = useInfiniteQuery<GetPostListResponse>({
+  const { data, isLoading, isError, isSuccess, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
+    useInfiniteQuery<GetPostListResponse>({
     queryKey: queryKeys.post.all(listParams).queryKey,
     queryFn: ({ pageParam = 1 }) => getPostList({ ...listParams, page: pageParam as number }),
     initialPageParam: 1,
@@ -47,8 +96,8 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
       : undefined,
     getNextPageParam: (lastPage) => {
       const currentPage = lastPage.meta?.pagination?.currentPage;
-      const hasNextPage = lastPage.meta?.pagination?.hasNextPage;
-      if (hasNextPage && currentPage) {
+      const nextPageExists = lastPage.meta?.pagination?.hasNextPage;
+      if (nextPageExists && currentPage) {
         return currentPage + 1;
       }
       return undefined;
@@ -60,8 +109,17 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
   const showLoading = isLoading && postsData.length === 0;
   const trackedKeyRef = useRef<string>('');
 
+  const handleLoadMore = () => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  };
+
+  const handleRetry = () => {
+    refetch();
+  };
+
   useEffect(() => {
-    if (showLoading || !hasFilters) return;
+    if (!isSuccess || showLoading || !hasFilters) return;
 
     const key = `${search}|${category}|${tagsParam}|${postsData.length}`;
     if (trackedKeyRef.current === key) return;
@@ -85,9 +143,25 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
         tag_count: tags.length,
       });
     }
-  }, [showLoading, hasFilters, search, category, tagsParam, tags.length, postsData.length]);
+  }, [isSuccess, showLoading, hasFilters, search, category, tagsParam, tags.length, postsData.length]);
 
-  if (!showLoading && postsData.length === 0) {
+  if (isError && postsData.length === 0) {
+    return (
+      <div className='mx-auto flex min-h-[40vh] w-full max-w-4xl flex-col items-center justify-center gap-4 px-4 py-16'>
+        <p className={`text-center text-sm ${blogTheme.textMuted}`}>글을 불러오지 못했습니다.</p>
+        <button
+          type='button'
+          onClick={handleRetry}
+          className={`rounded-lg px-4 py-2 text-sm ${blogTheme.navBtn}`}
+          aria-label='글 목록 다시 불러오기'
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  if (isSuccess && !showLoading && postsData.length === 0) {
     return (
       <div className='mx-auto w-full max-w-4xl'>
         <NoResults
@@ -112,6 +186,11 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
       <div className='mx-auto w-full max-w-4xl'>
         <BlogSectionTitle subtitle={filterLabel || '조건에 맞는 글'}>검색 결과</BlogSectionTitle>
         <PostList posts={postsData} isLoading={showLoading} />
+        <LoadMorePosts
+          hasNextPage={Boolean(hasNextPage)}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={handleLoadMore}
+        />
       </div>
     );
   }
@@ -130,6 +209,11 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
           <PostList posts={restPosts} isLoading={showLoading} />
         </>
       )}
+      <LoadMorePosts
+        hasNextPage={Boolean(hasNextPage)}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={handleLoadMore}
+      />
     </div>
   );
 };

--- a/src/widgets/post/ui/PostsLayoutShell.tsx
+++ b/src/widgets/post/ui/PostsLayoutShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
-import { SpaceBackground } from '@/widgets/post/ui';
+import { SpaceBackground } from '@/widgets/post/ui/SpaceBackground';
 import BlogHeader from '@/widgets/post/ui/BlogHeader';
 import Sidebar from '@/widgets/post/ui/Sidebar';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';

--- a/src/widgets/post/ui/SpaceBackground.tsx
+++ b/src/widgets/post/ui/SpaceBackground.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { motion } from 'framer-motion';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 
-const twilightStars = Array.from({ length: 40 }).map((_, i) => {
+const twilightStars = Array.from({ length: 24 }).map((_, i) => {
   const size = `${(i % 3) * 0.5 + 1.2}px`;
   const top = `${(i * 19) % 100}%`;
   const left = `${(i * 31) % 100}%`;
@@ -19,13 +18,12 @@ const twilightStars = Array.from({ length: 40 }).map((_, i) => {
         top,
         left,
         opacity,
-        boxShadow: '0 0 6px rgba(255, 200, 160, 0.35)',
       }}
     />
   );
 });
 
-const darkStars = Array.from({ length: 90 }).map((_, i) => {
+const darkStars = Array.from({ length: 40 }).map((_, i) => {
   const size = `${(i % 4) * 0.35 + 0.8}px`;
   const top = `${(i * 17) % 100}%`;
   const left = `${(i * 29) % 100}%`;
@@ -40,7 +38,6 @@ const darkStars = Array.from({ length: 90 }).map((_, i) => {
         top,
         left,
         opacity,
-        boxShadow: '0 0 8px rgba(61, 232, 255, 0.3)',
       }}
     />
   );
@@ -60,7 +57,6 @@ type PlanetConfig = {
   top: string;
   left: string;
   floatDuration: number;
-  driftDuration: number;
   hasRing?: boolean;
   light: PlanetPalette;
   dark: PlanetPalette;
@@ -73,7 +69,6 @@ const planets: PlanetConfig[] = [
     top: '11%',
     left: '86%',
     floatDuration: 9,
-    driftDuration: 240,
     hasRing: true,
     light: {
       sphere: 'radial-gradient(circle at 32% 28%, #ffd4a8 0%, #ff9a3c 28%, #c44d2a 62%, #3a1428 100%)',
@@ -98,7 +93,6 @@ const planets: PlanetConfig[] = [
     top: '72%',
     left: '9%',
     floatDuration: 7,
-    driftDuration: 320,
     light: {
       sphere: 'radial-gradient(circle at 35% 30%, #f0d0c0 0%, #b88878 35%, #5a3848 72%, #1a0e18 100%)',
       atmosphere: 'rgba(200, 140, 120, 0.12)',
@@ -114,7 +108,6 @@ const planets: PlanetConfig[] = [
     top: '30%',
     left: '14%',
     floatDuration: 11,
-    driftDuration: 280,
     hasRing: true,
     light: {
       sphere: 'radial-gradient(circle at 30% 26%, #f0c0e8 0%, #c878a8 30%, #6a2868 65%, #180818 100%)',
@@ -127,22 +120,6 @@ const planets: PlanetConfig[] = [
       atmosphere: 'rgba(99, 102, 241, 0.22)',
       ringStroke: 'rgba(129, 140, 248, 0.28)',
       ringFill: 'rgba(99, 102, 241, 0.05)',
-    },
-  },
-  {
-    id: 'horizon-pebble',
-    size: 22,
-    top: '52%',
-    left: '78%',
-    floatDuration: 6,
-    driftDuration: 360,
-    light: {
-      sphere: 'radial-gradient(circle at 38% 32%, #ffe0b8 0%, #e89050 40%, #804020 100%)',
-      atmosphere: 'rgba(255, 180, 100, 0.15)',
-    },
-    dark: {
-      sphere: 'radial-gradient(circle at 38% 32%, #b8e8ff 0%, #4898c8 42%, #183858 100%)',
-      atmosphere: 'rgba(61, 232, 255, 0.12)',
     },
   },
 ];
@@ -160,50 +137,7 @@ const PlanetRing = ({ size, stroke, fill }: { size: number; stroke: string; fill
     >
       <ellipse cx={w / 2} cy={h / 2} rx={w / 2 - 2} ry={h / 2 - 2} fill={fill} />
       <ellipse cx={w / 2} cy={h / 2} rx={w / 2 - 2} ry={h / 2 - 2} fill='none' stroke={stroke} strokeWidth='1.5' />
-      <ellipse
-        cx={w / 2}
-        cy={h / 2}
-        rx={w / 2 - 8}
-        ry={h / 2 - 5}
-        fill='none'
-        stroke={stroke}
-        strokeWidth='0.75'
-        opacity='0.5'
-      />
     </svg>
-  );
-};
-
-const PlanetSphere = ({
-  size,
-  palette,
-  driftDuration,
-}: {
-  size: number;
-  palette: PlanetPalette;
-  driftDuration: number;
-}) => {
-  return (
-    <motion.div
-      className='relative overflow-hidden rounded-full'
-      style={{ width: size, height: size }}
-      animate={{ rotate: 360 }}
-      transition={{ duration: driftDuration, repeat: Number.POSITIVE_INFINITY, ease: 'linear' }}
-    >
-      <div className='absolute inset-0 rounded-full' style={{ background: palette.sphere }} />
-      {palette.bands && (
-        <div className='absolute inset-0 rounded-full opacity-80' style={{ background: palette.bands }} />
-      )}
-      <div
-        className='absolute inset-0 rounded-full'
-        style={{
-          background:
-            'radial-gradient(circle at 72% 50%, transparent 36%, rgba(0,0,0,0.15) 58%, rgba(0,0,0,0.55) 100%)',
-        }}
-      />
-      <div className='absolute left-[16%] top-[14%] h-[20%] w-[26%] rounded-full bg-white/30 blur-[1px]' />
-      <div className='absolute left-[22%] top-[20%] h-[8%] w-[10%] rounded-full bg-white/50' />
-    </motion.div>
   );
 };
 
@@ -211,30 +145,36 @@ const Planet = ({ planet, isDark }: { planet: PlanetConfig; isDark: boolean }) =
   const palette = isDark ? planet.dark : planet.light;
 
   return (
-    <motion.div
-      className='absolute'
-      style={{ top: planet.top, left: planet.left, width: planet.size, height: planet.size }}
-      animate={{ y: [0, -8, 0] }}
-      transition={{
-        duration: planet.floatDuration,
-        repeat: Number.POSITIVE_INFINITY,
-        ease: 'easeInOut',
+    <div
+      className='blog-planet-float absolute'
+      style={{
+        top: planet.top,
+        left: planet.left,
+        width: planet.size,
+        height: planet.size,
+        ['--float-duration' as string]: `${planet.floatDuration}s`,
       }}
       aria-hidden
     >
       <div className='absolute inset-0' style={{ width: planet.size, height: planet.size }}>
         <div
-          className='absolute inset-[-35%] rounded-full blur-2xl'
+          className='absolute inset-[-20%] rounded-full opacity-70 blur-xl'
           style={{ background: `radial-gradient(circle, ${palette.atmosphere} 0%, transparent 70%)` }}
         />
         {planet.hasRing && palette.ringStroke && (
           <PlanetRing size={planet.size} stroke={palette.ringStroke} fill={palette.ringFill ?? 'transparent'} />
         )}
-        <div className='absolute left-0 top-0'>
-          <PlanetSphere size={planet.size} palette={palette} driftDuration={planet.driftDuration} />
+        <div
+          className='relative overflow-hidden rounded-full'
+          style={{ width: planet.size, height: planet.size }}
+        >
+          <div className='absolute inset-0 rounded-full' style={{ background: palette.sphere }} />
+          {palette.bands && (
+            <div className='absolute inset-0 rounded-full opacity-80' style={{ background: palette.bands }} />
+          )}
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 };
 
@@ -251,21 +191,13 @@ export const SpaceBackground = () => {
   return (
     <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden' aria-hidden>
       <div className='absolute inset-x-0 bottom-0 h-[45vh] bg-gradient-to-t from-[#ff9a3c]/25 via-[#8a4a68]/[0.15] to-transparent dark:hidden' />
-      <div className='absolute bottom-[-10%] left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[#ffc090]/30 blur-3xl dark:hidden' />
       <div className='absolute inset-0 hidden bg-gradient-to-b from-[#000010]/80 via-transparent to-[#000008]/60 dark:block' />
-
-      <div className='absolute inset-0 opacity-60 dark:opacity-80'>
-        <span className='absolute left-[8%] top-[38%] h-5 w-80 rotate-[-12deg] rounded-full bg-gradient-to-r from-orange-200/20 via-white/10 to-rose-200/[0.15] blur-2xl dark:from-blue-300/10 dark:via-white/[0.08] dark:to-purple-300/10' />
-        <span className='absolute left-[30%] top-[48%] h-4 w-96 rotate-[8deg] rounded-full bg-gradient-to-r from-amber-200/[0.15] via-white/[0.08] to-fuchsia-200/[0.12] blur-2xl dark:from-cyan-300/[0.08] dark:via-white/[0.06] dark:to-indigo-300/10' />
-      </div>
 
       {twilightStars}
       {darkStars}
 
       <div className='absolute -left-32 top-[10%] h-96 w-96 rounded-full bg-[#8a4a68]/20 blur-3xl dark:bg-[#3de8ff]/[0.06]' />
       <div className='absolute -right-24 top-[30%] h-72 w-72 rounded-full bg-[#ffc090]/[0.15] blur-3xl dark:bg-[#6366f1]/[0.08]' />
-      <div className='absolute bottom-[20%] left-[20%] h-64 w-64 rounded-full bg-[#c878ff]/10 blur-3xl dark:hidden' />
-      <div className='absolute right-[10%] top-[15%] hidden h-56 w-56 rounded-full bg-[#3de8ff]/5 blur-3xl dark:block' />
 
       {planets.map((planet) => (
         <Planet key={planet.id} planet={planet} isDark={isDark} />

--- a/src/widgets/post/ui/index.ts
+++ b/src/widgets/post/ui/index.ts
@@ -1,4 +1,7 @@
-export { Macintosh } from './Macintosh';
+/**
+ * 블로그 글 목록/상세용 경량 export만 유지.
+ * Macintosh / ComputerBackground 등 3D 모듈은 직접 경로로 import.
+ */
 export { BlogContent } from './BlogContent';
 export { BlogMainPage } from './BlogMainPage';
 export { default as BlogHeader } from './BlogHeader';
@@ -10,4 +13,3 @@ export { PostsLayoutShell } from './PostsLayoutShell';
 export { BlogSectionTitle } from './BlogSectionTitle';
 export { SearchBar } from './SearchBar';
 export { CategoryTree } from './CategoryTree';
-export * from './ComputerBackground/index';


### PR DESCRIPTION
## Summary
- 배럴 import side-effect로 블로그에서 홈용 GLB/텍스처가 내려가던 경로를 분리함
- 상세는 HTML 뷰어, 목록은 SSR hydrate로 JS·LCP를 줄임
- 카테고리 slug 이중 인코딩과 모바일 헤더 겹침을 함께 수정함

## Test plan
- [ ] `/blog/all` 모바일 Lighthouse Performance가 개선되는지 확인
- [ ] 포스트 상세에서 AI 요약·본문 스타일이 이전과 같이 보이는지 확인
- [ ] `/blog/category/회사` 진입 시 카테고리 API가 404가 아닌지 확인
- [ ] 모바일 너비에서 다크모드 버튼이 타이틀과 겹치지 않는지 확인
- [ ] `/` 홈 3D 씬과 `/blog` 랜딩 씬이 기존처럼 로드되는지 확인


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 블로그 랜딩 페이지에 인터랙티브 3D 장면과 스크롤 안내를 추가했습니다.
  * 게시글 목록의 페이지네이션과 초기 로딩 개선을 지원합니다.
  * HTML 게시글과 Mermaid 다이어그램을 읽기 전용으로 표시합니다.
  * 카테고리 및 게시글 URL 처리가 더욱 안정적으로 동작합니다.

* **개선 사항**
  * 모바일 블로그 헤더의 탐색, 로고, 테마 전환 배치를 개선했습니다.
  * 페이지 전환 효과와 로딩 상태를 조정해 접근성을 높였습니다.
  * 배경 장식과 애니메이션을 최적화하고 모션 감소 설정을 지원합니다.
  * 분석 스크립트가 페이지 성능에 미치는 영향을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->