### PR TITLE
fix: 카테고리 목록 API includePostCount=false 500 수정

### DIFF
--- a/app/api/category/all/route.ts
+++ b/app/api/category/all/route.ts
@@ -83,11 +83,20 @@ export async function GET(request: Request) {
         _count: {
           select: {
             children: true,
-            ...(includePostCount ? { posts: true } : {}),
+            posts: true,
           },
         },
       },
     });
+
+    if (!includePostCount) {
+      return NextResponse.json(
+        categories.map(({ _count, ...category }) => ({
+          ...category,
+          _count: { children: _count.children },
+        })),
+      );
+    }
 
     return NextResponse.json(categories);
   } catch (error) {

--- a/src/features/category/api/category-api.ts
+++ b/src/features/category/api/category-api.ts
@@ -1,9 +1,10 @@
 import type { Category } from '@/entities/category/model';
-import type { CategoryFormSchema } from '../model/category-schema';
 import { fetcher } from '@/shared/api';
+import type { CategoryFormSchema } from '../model/category-schema';
 
 // 카테고리 목록 조회
-export const getCategories = fetcher({ url: '/api/category/all', method: 'get', query: { includePostCount: false } });
+export const getCategories = () =>
+  fetcher({ url: '/api/category/all', method: 'get', query: { includePostCount: false } });
 
 // 새 카테고리 생성
 export const createCategory = async ({ name, description, parentId }: CategoryFormSchema) => {

--- a/src/features/category/model/use-category.ts
+++ b/src/features/category/model/use-category.ts
@@ -3,10 +3,7 @@ import { getCategories, getCategoryPosts } from '../api/category-api';
 import { queryKeys } from '@/shared/queryKeys';
 import type { CategoryResponse, CategoryWithPosts } from '@/entities/category/model';
 
-const getAllCategories = async () => {
-  const result = await getCategories;
-  return result;
-};
+const getAllCategories = () => getCategories();
 
 export const useCategories = <T extends CategoryResponse>() => {
   const { data, isLoading, error } = useQuery<T>({


### PR DESCRIPTION
## Summary
- `/api/category/all?includePostCount=false` 호출 시 Vercel에서 간헐적으로 500이 나던 문제 수정
- Prisma `_count.select` spread 분기 대신 고정 조회 후 응답에서 `posts` 제거
- `getCategories`를 모듈 로드 시 즉시 fetch하는 Promise에서 함수로 변경해 React Query가 매번 새로 요청

## Test plan
- [ ] Vercel 배포 후 `/api/category/all?includePostCount=false` 200 확인
- [ ] `/api/category/all?includePostCount=true` 응답에 `_count.posts` 포함 확인
- [ ] 블로그 사이드바 카테고리 목록 정상 로딩 확인