### PR TITLE
fix: Vercel serverless category/tags/상세 500 근본 수정

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -6,7 +6,7 @@ import type { PostResponse } from '@/entities/post/model/post';
 import { CommentSection } from '@/features/comment/ui';
 import { getPostBySlug } from '@/features/post/api/post-api';
 import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
-import PostHtmlViewer from '@/shared/ui/PostHtmlViewer';
+import { PostHtmlViewerClient } from '@/shared/ui/PostHtmlViewerClient';
 import { formatDateToYMD } from '@/shared/utils';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
@@ -198,7 +198,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           </div>
 
           <div className='relative z-10'>
-            <PostHtmlViewer content={post.content ?? ''} />
+            <PostHtmlViewerClient content={post.content ?? ''} />
           </div>
         </section>
 

--- a/app/api/category/all/route.ts
+++ b/app/api/category/all/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { parseCategoryParentId } from '@/entities/category';
 import prisma from '@/shared/lib/db';
-import { auth } from '@/shared/utils/auth';
 import { createSlug } from '@/shared/utils/create-slug';
 
 /**
@@ -100,7 +99,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json(categories);
   } catch (error) {
-    console.error('GET /api/categories error:', error);
+    console.error('GET /api/category/all error:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }
@@ -148,6 +147,7 @@ export async function GET(request: Request) {
  */
 export async function POST(request: Request) {
   try {
+    const { auth } = await import('@/shared/utils/auth');
     const session = await auth();
     if (!session || session.user.role !== 'ADMIN') {
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });

--- a/app/api/category/all/route.ts
+++ b/app/api/category/all/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { parseCategoryParentId } from '@/entities/category';
 import prisma from '@/shared/lib/db';
+import { READ_API_CACHE_HEADERS } from '@/shared/lib/api-cache-headers';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
 import { createSlug } from '@/shared/utils/create-slug';
 
 /**
@@ -74,19 +76,21 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const includePostCount = searchParams.get('includePostCount') === 'true';
 
-    const categories = await prisma.category.findMany({
-      orderBy: {
-        name: 'asc',
-      },
-      include: {
-        _count: {
-          select: {
-            children: true,
-            posts: true,
+    const categories = await withPrismaRetry(() =>
+      prisma.category.findMany({
+        orderBy: {
+          name: 'asc',
+        },
+        include: {
+          _count: {
+            select: {
+              children: true,
+              posts: true,
+            },
           },
         },
-      },
-    });
+      }),
+    );
 
     if (!includePostCount) {
       return NextResponse.json(
@@ -94,10 +98,11 @@ export async function GET(request: Request) {
           ...category,
           _count: { children: _count.children },
         })),
+        { headers: READ_API_CACHE_HEADERS },
       );
     }
 
-    return NextResponse.json(categories);
+    return NextResponse.json(categories, { headers: READ_API_CACHE_HEADERS });
   } catch (error) {
     console.error('GET /api/category/all error:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });

--- a/app/api/sidebar/route.ts
+++ b/app/api/sidebar/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/shared/lib/db';
+import { READ_API_CACHE_HEADERS } from '@/shared/lib/api-cache-headers';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
+
+/**
+ * 사이드바용 category + tags 단일 조회.
+ * 동시 lambda 2개 → 1개로 줄여 Supabase 연결 burst 완화.
+ */
+export async function GET() {
+  try {
+    const [categories, tags] = await withPrismaRetry(() =>
+      Promise.all([
+        prisma.category.findMany({
+          orderBy: { name: 'asc' },
+          include: {
+            _count: {
+              select: { children: true, posts: true },
+            },
+          },
+        }),
+        prisma.tag.findMany({
+          include: {
+            _count: {
+              select: { posts: true },
+            },
+          },
+        }),
+      ]),
+    );
+
+    return NextResponse.json(
+      {
+        categories: categories.map(({ _count, ...category }) => ({
+          ...category,
+          _count: { children: _count.children },
+        })),
+        tags: tags.map(({ _count, ...tag }) => ({
+          ...tag,
+          count: _count.posts,
+        })),
+      },
+      { headers: READ_API_CACHE_HEADERS },
+    );
+  } catch (error) {
+    console.error('GET /api/sidebar error:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { getBaseUrl } from '@/shared/lib/get-base-url';
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 /** 개별 free 모델은 자주 deprecated 되므로 auto-router 사용 */
@@ -124,7 +125,7 @@ export async function POST(request: NextRequest) {
       headers: {
         Authorization: `Bearer ${OPENROUTER_API_KEY}`,
         'Content-Type': 'application/json',
-        'HTTP-Referer': process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000',
+        'HTTP-Referer': getBaseUrl(),
         'X-Title': '3d-blog',
       },
       body: JSON.stringify({

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -56,6 +56,7 @@ export async function GET() {
     }));
     return NextResponse.json(result);
   } catch (error) {
+    console.error('GET /api/tags error:', error);
     return NextResponse.json({ error: 'Failed to fetch tags' }, { status: 500 });
   }
 }

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/shared/lib/db';
+import { READ_API_CACHE_HEADERS } from '@/shared/lib/api-cache-headers';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
 
 /**
  * @swagger
@@ -43,18 +45,20 @@ import prisma from '@/shared/lib/db';
  */
 export async function GET() {
   try {
-    const tags = await prisma.tag.findMany({
-      include: {
-        _count: {
-          select: { posts: true },
+    const tags = await withPrismaRetry(() =>
+      prisma.tag.findMany({
+        include: {
+          _count: {
+            select: { posts: true },
+          },
         },
-      },
-    });
+      }),
+    );
     const result = tags.map(({ _count, ...tag }) => ({
       ...tag,
       count: _count.posts,
     }));
-    return NextResponse.json(result);
+    return NextResponse.json(result, { headers: READ_API_CACHE_HEADERS });
   } catch (error) {
     console.error('GET /api/tags error:', error);
     return NextResponse.json({ error: 'Failed to fetch tags' }, { status: 500 });

--- a/src/entities/tag/lib/get-tag-post-count.ts
+++ b/src/entities/tag/lib/get-tag-post-count.ts
@@ -1,0 +1,9 @@
+type TagWithCount = {
+  count?: number | { posts?: number };
+};
+
+/** /api/tags 응답: count는 number, OpenAPI 타입은 { posts } 형태일 수 있음 */
+export const getTagPostCount = (tag: TagWithCount) => {
+  if (typeof tag.count === 'number') return tag.count;
+  return tag.count?.posts ?? 0;
+};

--- a/src/features/category/model/use-category.ts
+++ b/src/features/category/model/use-category.ts
@@ -9,6 +9,9 @@ export const useCategories = <T extends CategoryResponse>() => {
   const { data, isLoading, error } = useQuery<T>({
     queryKey: queryKeys.category.all.queryKey,
     queryFn: getAllCategories,
+    staleTime: 5 * 60 * 1000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
   });
 
   return { data, isLoading, error };

--- a/src/features/sidebar/api/sidebar-api.ts
+++ b/src/features/sidebar/api/sidebar-api.ts
@@ -1,0 +1,17 @@
+import type { CategoryResponse } from '@/entities/category/model';
+import type { TagResponse } from '@/entities/tag/model';
+
+export type SidebarData = {
+  categories: CategoryResponse;
+  tags: TagResponse;
+};
+
+export const getSidebarData = async (): Promise<SidebarData> => {
+  const response = await fetch('/api/sidebar', { cache: 'no-store' });
+
+  if (!response.ok) {
+    throw new Error(`Sidebar fetch failed: ${response.status}`);
+  }
+
+  return response.json();
+};

--- a/src/features/sidebar/model/use-sidebar-data.ts
+++ b/src/features/sidebar/model/use-sidebar-data.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSidebarData } from '../api/sidebar-api';
+
+const SIDEBAR_QUERY_KEY = ['sidebar'] as const;
+
+export const useSidebarData = () => {
+  return useQuery({
+    queryKey: SIDEBAR_QUERY_KEY,
+    queryFn: getSidebarData,
+    staleTime: 5 * 60 * 1000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
+  });
+};

--- a/src/features/tag/model/use-tags.ts
+++ b/src/features/tag/model/use-tags.ts
@@ -7,6 +7,9 @@ export const useTags = <T extends TagResponse>() => {
   const { data, isLoading, error } = useQuery<T>({
     queryKey: TAG_QUERY_KEY.all.queryKey,
     queryFn: () => getAllTag(),
+    staleTime: 5 * 60 * 1000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
   });
 
   return { data, isLoading, error };

--- a/src/features/tag/ui/Tag.tsx
+++ b/src/features/tag/ui/Tag.tsx
@@ -10,6 +10,8 @@ const colorCombos = [
   'bg-indigo-500 border-indigo-200 dark:bg-indigo-500 dark:border-indigo-200',
 ];
 
+const getTagHref = (name: string) => `/blog/all?tags=${encodeURIComponent(name)}`;
+
 export const Tag = ({ tag, count }: { tag: { id?: number; name?: string }; count: number }) => {
   function hashString(str: string) {
     let hash = 0;
@@ -29,7 +31,7 @@ export const Tag = ({ tag, count }: { tag: { id?: number; name?: string }; count
       className='relative rounded-lg border border-[#ff9a3c]/25 bg-[#ff9a3c]/8 px-2 py-1 text-xs font-mono shadow-[0_0_10px_rgba(255,154,60,0.1)] transition dark:border-[#3de8ff]/25 dark:bg-[#3de8ff]/8 dark:shadow-[0_0_10px_rgba(61,232,255,0.1)]'
     >
       <Link
-        href={`/blog/${tag.name}`}
+        href={getTagHref(tag.name ?? '')}
         className='inline-block px-3 py-1 text-xs font-mono text-[#ffc8a0] backdrop-blur-sm dark:text-[#3de8ff]'
       >
         {tag.name}

--- a/src/shared/api/fetcher.ts
+++ b/src/shared/api/fetcher.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
 import qs, { type ParsedUrlQueryInput } from 'querystring';
+import { getBaseUrl } from '@/shared/lib/get-base-url';
 import type { paths } from './openapi-types';
 
 type Path = keyof paths;
@@ -86,8 +87,7 @@ export const fetcher = async <P extends Path, M extends Method<P>>({
   // 서버 환경에서 finalUrl이 /로 시작하면 절대경로로 변환 (URL이 path를 1회 인코딩)
   const isServer = typeof window === 'undefined';
   if (isServer && finalUrl.startsWith('/')) {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-    finalUrl = new URL(finalUrl, baseUrl).href;
+    finalUrl = new URL(finalUrl, getBaseUrl()).href;
   }
 
   const res = await fetch(finalUrl, {

--- a/src/shared/consts/baseUrl.ts
+++ b/src/shared/consts/baseUrl.ts
@@ -1,4 +1,6 @@
-export const baseUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000').replace(/\/$/, '');
+import { getBaseUrl } from '@/shared/lib/get-base-url';
+
+export const baseUrl = getBaseUrl();
 
 export const toAbsoluteUrl = (path: string) => {
   if (!path) return baseUrl;

--- a/src/shared/lib/api-cache-headers.ts
+++ b/src/shared/lib/api-cache-headers.ts
@@ -1,0 +1,4 @@
+/** Vercel CDN 캐시: DB hit 줄이고 cold start burst 완화 */
+export const READ_API_CACHE_HEADERS = {
+  'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+} as const;

--- a/src/shared/lib/db.ts
+++ b/src/shared/lib/db.ts
@@ -2,7 +2,9 @@
 import { PrismaClient } from '@prisma/client';
 
 const prismaClientSingleton = () => {
-  return new PrismaClient();
+  return new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
+  });
 };
 
 declare global {

--- a/src/shared/lib/db.ts
+++ b/src/shared/lib/db.ts
@@ -13,4 +13,5 @@ const prisma = globalThis.prisma ?? prismaClientSingleton();
 
 export default prisma;
 
-if (process.env.NODE_ENV !== 'production') globalThis.prisma = prisma;
+// Vercel serverless: 인스턴스당 PrismaClient 1개만 유지 (연결 폭주 방지)
+globalThis.prisma = prisma;

--- a/src/shared/lib/get-base-url.ts
+++ b/src/shared/lib/get-base-url.ts
@@ -1,0 +1,10 @@
+/** SSR/서버 fetch용 절대 URL. Vercel에서는 VERCEL_URL을 자동 사용 */
+export const getBaseUrl = () => {
+  const fromEnv = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '');
+  if (fromEnv) return fromEnv;
+
+  const vercelHost = process.env.VERCEL_URL?.replace(/\/$/, '');
+  if (vercelHost) return `https://${vercelHost}`;
+
+  return 'http://localhost:3000';
+};

--- a/src/shared/lib/with-prisma-retry.ts
+++ b/src/shared/lib/with-prisma-retry.ts
@@ -1,0 +1,48 @@
+import { Prisma } from '@prisma/client';
+
+const RETRIABLE_PRISMA_CODES = new Set([
+  'P1001', // Can't reach database server
+  'P1002', // Database server timed out
+  'P1008', // Operations timed out
+  'P1017', // Server has closed the connection
+  'P2024', // Timed out fetching a new connection from the connection pool
+]);
+
+const RETRIABLE_MESSAGE = /connection|timeout|econnreset|econnrefused|too many clients/i;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isRetriableError = (error: unknown) => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return RETRIABLE_PRISMA_CODES.has(error.code);
+  }
+
+  if (error instanceof Prisma.PrismaClientInitializationError) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    return RETRIABLE_MESSAGE.test(error.message);
+  }
+
+  return false;
+};
+
+/** Supabase pooler 일시 장애·cold start 시 재시도 */
+export const withPrismaRetry = async <T>(operation: () => Promise<T>, maxAttempts = 3): Promise<T> => {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isRetriableError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(150 * 2 ** (attempt - 1));
+    }
+  }
+
+  throw lastError;
+};

--- a/src/shared/ui/PostHtmlViewerClient.tsx
+++ b/src/shared/ui/PostHtmlViewerClient.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const PostHtmlViewer = dynamic(() => import('@/shared/ui/PostHtmlViewer'), {
+  ssr: false,
+  loading: () => <div className='blog-prose min-h-[120px]' aria-busy='true' role='status' />,
+});
+
+type PostHtmlViewerClientProps = {
+  content: string;
+};
+
+export const PostHtmlViewerClient = ({ content }: PostHtmlViewerClientProps) => {
+  return <PostHtmlViewer content={content} />;
+};

--- a/src/widgets/post/ui/MobileNavbar.tsx
+++ b/src/widgets/post/ui/MobileNavbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { toCategoryListItems } from '@/entities/category';
+import { getTagPostCount } from '@/entities/tag/lib/get-tag-post-count';
 import { useCategories } from '@/features/category/model';
 import { useTags } from '@/features/tag/model/use-tags';
 import { Tag } from '@/features/tag/ui';
@@ -97,7 +98,7 @@ export const MobileNavbar = ({
               </h2>
               <div className='flex flex-wrap gap-2'>
                 {tags?.map((tag) => (
-                  <Tag key={tag.id} tag={tag} count={tag.count?.posts ?? 0} />
+                  <Tag key={tag.id} tag={tag} count={getTagPostCount(tag)} />
                 ))}
               </div>
             </div>

--- a/src/widgets/post/ui/MobileNavbar.tsx
+++ b/src/widgets/post/ui/MobileNavbar.tsx
@@ -2,8 +2,7 @@
 
 import { toCategoryListItems } from '@/entities/category';
 import { getTagPostCount } from '@/entities/tag/lib/get-tag-post-count';
-import { useCategories } from '@/features/category/model';
-import { useTags } from '@/features/tag/model/use-tags';
+import { useSidebarData } from '@/features/sidebar/model/use-sidebar-data';
 import { Tag } from '@/features/tag/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname, useRouter } from 'next/navigation';
@@ -18,11 +17,11 @@ export const MobileNavbar = ({
   menuOpen: boolean;
   setMenuOpen: (menuOpen: boolean) => void;
 }) => {
-  const { data } = useCategories();
-  const { data: tags } = useTags();
+  const { data: sidebarData } = useSidebarData();
   const router = useRouter();
   const pathname = usePathname();
-  const categories = useMemo(() => toCategoryListItems(data), [data]);
+  const categories = useMemo(() => toCategoryListItems(sidebarData?.categories), [sidebarData?.categories]);
+  const tags = sidebarData?.tags;
 
   const currentCategorySlug = (() => {
     const match = pathname.match(/^\/blog\/category\/([^/]+)/);

--- a/src/widgets/post/ui/Sidebar.tsx
+++ b/src/widgets/post/ui/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { toCategoryListItems } from '@/entities/category';
+import { getTagPostCount } from '@/entities/tag/lib/get-tag-post-count';
 import { VisitorCounter } from '@/features/blog/ui';
 import { useCategories } from '@/features/category/model';
 import { useTags } from '@/features/tag/model/use-tags';
@@ -91,7 +92,7 @@ export default function Sidebar() {
               </div>
               <div className='flex flex-wrap gap-2'>
                 {tags?.map((tag) => (
-                  <Tag key={tag.id} tag={tag} count={tag.count?.posts ?? 0} />
+                  <Tag key={tag.id} tag={tag} count={getTagPostCount(tag)} />
                 ))}
               </div>
             </div>

--- a/src/widgets/post/ui/Sidebar.tsx
+++ b/src/widgets/post/ui/Sidebar.tsx
@@ -3,8 +3,7 @@
 import { toCategoryListItems } from '@/entities/category';
 import { getTagPostCount } from '@/entities/tag/lib/get-tag-post-count';
 import { VisitorCounter } from '@/features/blog/ui';
-import { useCategories } from '@/features/category/model';
-import { useTags } from '@/features/tag/model/use-tags';
+import { useSidebarData } from '@/features/sidebar/model/use-sidebar-data';
 import { Tag } from '@/features/tag/ui';
 import { SidebarSkeleton } from '@/shared/ui/skeleton';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -17,10 +16,10 @@ import { CategoryTree } from './CategoryTree';
 export default function Sidebar() {
   const router = useRouter();
   const pathname = usePathname();
-  const { data, isLoading } = useCategories();
+  const { data: sidebarData, isLoading } = useSidebarData();
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const { data: tags } = useTags();
-  const categories = useMemo(() => toCategoryListItems(data), [data]);
+  const categories = useMemo(() => toCategoryListItems(sidebarData?.categories), [sidebarData?.categories]);
+  const tags = sidebarData?.tags;
 
   const currentCategorySlug = (() => {
     const match = pathname.match(/^\/blog\/category\/([^/]+)/);


### PR DESCRIPTION
## Summary
- PrismaClient를 production serverless에서도 `globalThis`에 캐시해 DB 연결 폭주로 인한 간헐적 API 500 방지
- SSR self-fetch 시 `VERCEL_URL` fallback 추가
- PostHtmlViewer를 ssr:false 클라이언트 래퍼로 분리해 jsdom 서버 번들 완전 제거
- /api/category/all GET에서 NextAuth top-level import 제거

## Test plan
- [ ] /api/category/all?includePostCount=false 200
- [ ] /api/tags 200
- [ ] 블로그 상세 페이지 200
- [ ] 사이드바 category/tags 정상