### PR TITLE
fix: admin 500·머메이드·목록 무한 스크롤 후속 수정

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import { PostListCard } from '@/features/blog/ui';
-import { useCategoryPosts } from '@/features/category/model';
+import { useCategoryPostsInfinite } from '@/features/category/model';
 import { PostListCardSkeleton } from '@/shared/ui/skeleton';
+import { LoadMoreSentinel } from '@/widgets/post/ui/LoadMoreSentinel';
 
 export default function BlogPostPage() {
   const { slug: rawSlug } = useParams();
@@ -15,9 +17,23 @@ export default function BlogPostPage() {
       return value;
     }
   })();
-  const { data: categoryPosts, isLoading: isCategoryPostsLoading } = useCategoryPosts(slug, 1, 10);
 
-  if (isCategoryPostsLoading) {
+  const {
+    categoryName,
+    categorySlug,
+    posts,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useCategoryPostsInfinite(slug, 10);
+
+  const handleLoadMore = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  if (isLoading && posts.length === 0) {
     return (
       <div className='mx-auto flex w-full max-w-4xl flex-col gap-8' aria-busy='true'>
         {['a', 'b', 'c', 'd', 'e'].map((id) => (
@@ -29,9 +45,19 @@ export default function BlogPostPage() {
 
   return (
     <div className='mx-auto w-full max-w-4xl'>
-      {categoryPosts?.posts?.map((post) => (
-        <PostListCard key={post.id} post={post} categoryName={categoryPosts?.name} categorySlug={categoryPosts?.slug} />
+      {posts.map((post) => (
+        <PostListCard
+          key={post.id}
+          post={post}
+          categoryName={categoryName}
+          categorySlug={categorySlug}
+        />
       ))}
+      <LoadMoreSentinel
+        hasNextPage={Boolean(hasNextPage)}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={handleLoadMore}
+      />
     </div>
   );
-}
+};

--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -6,7 +6,7 @@ import type { PostResponse } from '@/entities/post/model/post';
 import { CommentSection } from '@/features/comment/ui';
 import { getPostBySlug } from '@/features/post/api/post-api';
 import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
-import { PostHtmlViewerClient } from '@/shared/ui/PostHtmlViewerClient';
+import { PostContentViewer } from '@/shared/ui/PostContentViewer';
 import { formatDateToYMD } from '@/shared/utils';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { PostBackButton } from '@/widgets/post/ui/PostBackButton';
@@ -198,7 +198,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           </div>
 
           <div className='relative z-10'>
-            <PostHtmlViewerClient content={post.content ?? ''} />
+            <PostContentViewer content={post.content ?? ''} />
           </div>
         </section>
 

--- a/app/api/category/[slug]/route.ts
+++ b/app/api/category/[slug]/route.ts
@@ -189,6 +189,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
         limit,
         total: totalPosts,
         totalPages: Math.ceil(totalPosts / limit),
+        hasNextPage: page < Math.ceil(totalPosts / limit),
       },
     });
   } catch (error) {

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -184,12 +184,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({
       data: posts,
       meta: {
-        currentPage: page,
-        totalPages: Math.ceil(totalItems / limit),
-        totalItems,
-        itemsPerPage: limit,
-        hasNextPage: page < Math.ceil(totalItems / limit),
-        hasPrevPage: page > 1,
+        pagination: {
+          currentPage: page,
+          totalPages: Math.ceil(totalItems / limit),
+          totalItems,
+          itemsPerPage: limit,
+          hasNextPage: page < Math.ceil(totalItems / limit),
+          hasPrevPage: page > 1,
+        },
       },
     });
   } catch (error) {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getStats } from '@/features/admin/home/api/stats-api';
+import { READ_API_CACHE_HEADERS } from '@/shared/lib/api-cache-headers';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
 
 /**
  * @swagger
@@ -78,8 +80,8 @@ import { getStats } from '@/features/admin/home/api/stats-api';
  */
 export async function GET() {
   try {
-    const stats = await getStats();
-    return NextResponse.json(stats);
+    const stats = await withPrismaRetry(() => getStats());
+    return NextResponse.json(stats, { headers: READ_API_CACHE_HEADERS });
   } catch (error) {
     console.error('Error fetching stats:', error);
     return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -663,6 +663,33 @@ pre {
   color: #c8e8ff;
 }
 
+/* Mermaid SVG — blog-prose color 상속으로 글자가 사라지는 문제 방지 */
+.blog-prose .mermaid-diagram svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.blog-prose .mermaid-diagram .nodeLabel,
+.blog-prose .mermaid-diagram .label,
+.blog-prose .mermaid-diagram .cluster-label,
+.blog-prose .mermaid-diagram text,
+.blog-prose .mermaid-diagram .messageText,
+.blog-prose .mermaid-diagram .loopText {
+  fill: #ffe8d0 !important;
+  color: #ffe8d0 !important;
+}
+
+.dark .blog-prose .mermaid-diagram .nodeLabel,
+.dark .blog-prose .mermaid-diagram .label,
+.dark .blog-prose .mermaid-diagram .cluster-label,
+.dark .blog-prose .mermaid-diagram text,
+.dark .blog-prose .mermaid-diagram .messageText,
+.dark .blog-prose .mermaid-diagram .loopText {
+  fill: #c8e8ff !important;
+  color: #c8e8ff !important;
+}
+
 .void-scanlines::after {
   pointer-events: none;
   content: "";

--- a/src/features/admin/home/api/stats-api.ts
+++ b/src/features/admin/home/api/stats-api.ts
@@ -1,101 +1,71 @@
+import { cache } from 'react';
 import prisma from '@/shared/lib/db';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
 
-export const getStats = async () => {
-  try {
+export type AdminStats = {
+  posts: {
+    total: number;
+    thisMonth: number;
+    lastMonth: number;
+  };
+  users: {
+    total: number;
+    thisMonth: number;
+    lastMonth: number;
+  };
+  comments: {
+    total: number;
+    thisMonth: number;
+    lastMonth: number;
+  };
+  views: {
+    total: number;
+    thisMonth: number;
+    lastMonth: number;
+  };
+};
+
+/** Supabase session pool burst 방지: 요청당 1회, 쿼리는 순차 실행 */
+export const getStats = cache(async (): Promise<AdminStats> => {
+  return withPrismaRetry(async () => {
     const now = new Date();
     const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
     const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
     const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0);
 
-    // 게시물 통계
-    const [totalPosts, thisMonthPosts, lastMonthPosts] = await Promise.all([
-      prisma.post.count(),
-      prisma.post.count({
-        where: {
-          createdAt: {
-            gte: thisMonthStart,
-          },
-        },
-      }),
-      prisma.post.count({
-        where: {
-          createdAt: {
-            gte: lastMonthStart,
-            lte: lastMonthEnd,
-          },
-        },
-      }),
-    ]);
+    const totalPosts = await prisma.post.count();
+    const thisMonthPosts = await prisma.post.count({
+      where: { createdAt: { gte: thisMonthStart } },
+    });
+    const lastMonthPosts = await prisma.post.count({
+      where: { createdAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+    });
 
-    // 사용자 통계
-    const [totalUsers, thisMonthUsers, lastMonthUsers] = await Promise.all([
-      prisma.user.count(),
-      prisma.user.count({
-        where: {
-          createdAt: {
-            gte: thisMonthStart,
-          },
-        },
-      }),
-      prisma.user.count({
-        where: {
-          createdAt: {
-            gte: lastMonthStart,
-            lte: lastMonthEnd,
-          },
-        },
-      }),
-    ]);
+    const totalUsers = await prisma.user.count();
+    const thisMonthUsers = await prisma.user.count({
+      where: { createdAt: { gte: thisMonthStart } },
+    });
+    const lastMonthUsers = await prisma.user.count({
+      where: { createdAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+    });
 
-    // 댓글 통계
-    const [totalComments, thisMonthComments, lastMonthComments] = await Promise.all([
-      prisma.comment.count(),
-      prisma.comment.count({
-        where: {
-          createdAt: {
-            gte: thisMonthStart,
-          },
-        },
-      }),
-      prisma.comment.count({
-        where: {
-          createdAt: {
-            gte: lastMonthStart,
-            lte: lastMonthEnd,
-          },
-        },
-      }),
-    ]);
+    const totalComments = await prisma.comment.count();
+    const thisMonthComments = await prisma.comment.count({
+      where: { createdAt: { gte: thisMonthStart } },
+    });
+    const lastMonthComments = await prisma.comment.count({
+      where: { createdAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+    });
 
-    // 조회수 통계
-    const [totalViews, thisMonthViews, lastMonthViews] = await Promise.all([
-      prisma.post.aggregate({
-        _sum: {
-          views: true,
-        },
-      }),
-      prisma.post.aggregate({
-        _sum: {
-          views: true,
-        },
-        where: {
-          createdAt: {
-            gte: thisMonthStart,
-          },
-        },
-      }),
-      prisma.post.aggregate({
-        _sum: {
-          views: true,
-        },
-        where: {
-          createdAt: {
-            gte: lastMonthStart,
-            lte: lastMonthEnd,
-          },
-        },
-      }),
-    ]);
+    const totalViews = await prisma.post.aggregate({ _sum: { views: true } });
+    const thisMonthViews = await prisma.post.aggregate({
+      _sum: { views: true },
+      where: { createdAt: { gte: thisMonthStart } },
+    });
+    const lastMonthViews = await prisma.post.aggregate({
+      _sum: { views: true },
+      where: { createdAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+    });
 
     return {
       posts: {
@@ -114,13 +84,10 @@ export const getStats = async () => {
         lastMonth: lastMonthComments,
       },
       views: {
-        total: totalViews._sum.views || 0,
-        thisMonth: thisMonthViews._sum.views || 0,
-        lastMonth: lastMonthViews._sum.views || 0,
+        total: totalViews._sum.views ?? 0,
+        thisMonth: thisMonthViews._sum.views ?? 0,
+        lastMonth: lastMonthViews._sum.views ?? 0,
       },
     };
-  } catch (error) {
-    console.error('Failed to get stats:', error);
-    throw new Error('Failed to fetch stats');
-  }
-};
+  });
+});

--- a/src/features/admin/home/ui/PostsCard.tsx
+++ b/src/features/admin/home/ui/PostsCard.tsx
@@ -1,12 +1,15 @@
-import { getStats } from '../api/stats-api';
+import type { AdminStats } from '../api/stats-api';
 import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from '@/shadcn-ui/components/ui/card';
 import { Tag } from '@/shared/ui/Tag';
 import { adminTheme } from '@/widgets/admin/ui/admin-theme';
 import { TrendingDown, TrendingUp } from 'lucide-react';
 
-export async function PostsCard() {
-  const stats = await getStats();
-  const { total, thisMonth, lastMonth } = stats.posts;
+type PostsCardProps = {
+  posts: AdminStats['posts'];
+};
+
+export function PostsCard({ posts }: PostsCardProps) {
+  const { total, thisMonth, lastMonth } = posts;
   const growthRate = lastMonth > 0 ? ((thisMonth - lastMonth) / lastMonth) * 100 : 0;
   const isPositive = growthRate >= 0;
 

--- a/src/features/admin/home/ui/TotalViewsCard.tsx
+++ b/src/features/admin/home/ui/TotalViewsCard.tsx
@@ -1,12 +1,15 @@
-import { getStats } from '../api/stats-api';
+import type { AdminStats } from '../api/stats-api';
 import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from '@/shadcn-ui/components/ui/card';
 import { Tag } from '@/shared/ui/Tag';
 import { adminTheme } from '@/widgets/admin/ui/admin-theme';
 import { TrendingUp } from 'lucide-react';
 
-export async function TotalViewsCard() {
-  const stats = await getStats();
-  const { total, thisMonth, lastMonth } = stats.views;
+type TotalViewsCardProps = {
+  views: AdminStats['views'];
+};
+
+export function TotalViewsCard({ views }: TotalViewsCardProps) {
+  const { total, thisMonth, lastMonth } = views;
 
   return (
     <Card className={adminTheme.card}>

--- a/src/features/admin/home/ui/UsersCard.tsx
+++ b/src/features/admin/home/ui/UsersCard.tsx
@@ -1,12 +1,13 @@
-import { getUserCount } from '@/features/user/api/user-api';
 import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from '@/shadcn-ui/components/ui/card';
 import { Tag } from '@/shared/ui/Tag';
 import { adminTheme } from '@/widgets/admin/ui/admin-theme';
 import { Users } from 'lucide-react';
 
-export async function UsersCard() {
-  const userCount = await getUserCount();
+type UsersCardProps = {
+  userCount: number;
+};
 
+export function UsersCard({ userCount }: UsersCardProps) {
   return (
     <Card className={adminTheme.card}>
       <span className={adminTheme.cardTopGlow} aria-hidden />

--- a/src/features/admin/home/ui/VisitorsCard.tsx
+++ b/src/features/admin/home/ui/VisitorsCard.tsx
@@ -1,19 +1,21 @@
-import { getVisitor } from '@/features/visitor/api';
+import type { VisitorResponse } from '@/entities/visitor/model/visitor';
 import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from '@/shadcn-ui/components/ui/card';
 import { Tag } from '@/shared/ui/Tag';
 import { adminTheme } from '@/widgets/admin/ui/admin-theme';
 import { TrendingUp } from 'lucide-react';
 
-export async function VisitorsCard() {
-  const visitor = await getVisitor();
+type VisitorsCardProps = {
+  visitor: VisitorResponse;
+};
 
+export function VisitorsCard({ visitor }: VisitorsCardProps) {
   return (
     <Card className={adminTheme.card}>
       <span className={adminTheme.cardTopGlow} aria-hidden />
       <CardHeader className='pb-0'>
         <CardDescription className={adminTheme.sectionLabel}>방문자</CardDescription>
         <CardTitle className={`text-2xl font-semibold tabular-nums @[250px]/card:text-3xl ${adminTheme.textPrimary}`}>
-          {visitor.total.toLocaleString()}
+          {(visitor.total ?? 0).toLocaleString()}
         </CardTitle>
         <CardAction>
           <Tag color='orange' size='sm' type='glass' className='flex items-center gap-1.5 border-white/20'>

--- a/src/features/category/model/use-category.ts
+++ b/src/features/category/model/use-category.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { getCategories, getCategoryPosts } from '../api/category-api';
 import { queryKeys } from '@/shared/queryKeys';
+import { getNextPageParamFromMeta } from '@/shared/lib/pagination';
 import type { CategoryResponse, CategoryWithPosts } from '@/entities/category/model';
 
 const getAllCategories = () => getCategories();
@@ -24,4 +25,31 @@ export const useCategoryPosts = (slug: string, page = 1, limit = 10) => {
   });
 
   return { data, isLoading, error };
+};
+
+export const useCategoryPostsInfinite = (slug: string, limit = 10) => {
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
+    useInfiniteQuery<CategoryWithPosts>({
+      queryKey: [...queryKeys.category.posts(slug, 1, limit).queryKey, 'infinite'],
+      queryFn: ({ pageParam = 1 }) => getCategoryPosts(slug, pageParam as number, limit),
+      initialPageParam: 1,
+      getNextPageParam: (lastPage) => getNextPageParamFromMeta(lastPage),
+      staleTime: 60_000,
+      enabled: Boolean(slug),
+    });
+
+  const categoryInfo = data?.pages[0];
+  const posts = data?.pages.flatMap((page) => page.posts ?? []) ?? [];
+
+  return {
+    categoryName: categoryInfo?.name,
+    categorySlug: categoryInfo?.slug,
+    posts,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  };
 };

--- a/src/features/post/model/use-post.ts
+++ b/src/features/post/model/use-post.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery, useQuery, keepPreviousData } from '@tanstack/react-query';
 import { getPostList } from '../api/post-api';
 import { queryKeys } from '@/shared/queryKeys';
+import { getNextPageParamFromMeta } from '@/shared/lib/pagination';
 import type { GetPostListResponse } from './post-types';
 import type { GetPostListParams } from './post-types';
 
@@ -10,19 +11,11 @@ export const usePost = <T extends GetPostListResponse>(params: GetPostListParams
     queryFn: ({ pageParam = 1 }) => getPostList({ ...params, page: pageParam as number }),
     select: (data) => data,
     initialPageParam: 1,
-    getNextPageParam: (lastPage) => {
-      const currentPage = lastPage.meta?.pagination?.currentPage;
-      const hasNextPage = lastPage.meta?.pagination?.hasNextPage;
-      if (hasNextPage && currentPage) {
-        return currentPage + 1;
-      }
-      return undefined;
-    },
+    getNextPageParam: (lastPage) => getNextPageParamFromMeta(lastPage),
     getPreviousPageParam: (firstPage) => {
-      const currentPage = firstPage.meta?.pagination?.currentPage;
-      const hasPrevPage = firstPage.meta?.pagination?.hasPrevPage;
-      if (hasPrevPage && currentPage) {
-        return currentPage - 1;
+      const pagination = firstPage.meta?.pagination;
+      if (pagination?.hasPrevPage && pagination.currentPage) {
+        return pagination.currentPage - 1;
       }
       return undefined;
     },

--- a/src/shared/lib/db.ts
+++ b/src/shared/lib/db.ts
@@ -1,9 +1,18 @@
 /* eslint-disable */
 import { PrismaClient } from '@prisma/client';
+import { getDatabaseUrl } from './get-database-url';
 
 const prismaClientSingleton = () => {
+  const databaseUrl = getDatabaseUrl();
   return new PrismaClient({
     log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
+    ...(databaseUrl
+      ? {
+          datasources: {
+            db: { url: databaseUrl },
+          },
+        }
+      : {}),
   });
 };
 

--- a/src/shared/lib/get-database-url.ts
+++ b/src/shared/lib/get-database-url.ts
@@ -1,0 +1,16 @@
+const appendQueryParam = (url: string, key: string, value: string) => {
+  if (new RegExp(`[?&]${key}=`).test(url)) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}${key}=${value}`;
+};
+
+/** Supabase pooler: 인스턴스당 연결 1개로 제한 */
+export const getDatabaseUrl = () => {
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined;
+
+  let next = appendQueryParam(url, 'connection_limit', '1');
+  if (next.includes(':6543')) {
+    next = appendQueryParam(next, 'pgbouncer', 'true');
+  }
+  return next;
+};

--- a/src/shared/lib/mermaid-render.ts
+++ b/src/shared/lib/mermaid-render.ts
@@ -1,0 +1,64 @@
+import { getCodeBlockText } from '@/shared/utils/process-html';
+
+let mermaidInitialized = false;
+
+const MERMAID_CODE_SELECTOR = 'pre code.language-mermaid, pre code[class*="language-mermaid"]';
+
+const initMermaid = async () => {
+  const { default: mermaid } = await import('mermaid');
+  if (!mermaidInitialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'dark',
+      themeVariables: {
+        background: '#1c0e38',
+        primaryColor: '#2a1a4a',
+        primaryTextColor: '#ffe8d0',
+        primaryBorderColor: '#ff9a3c',
+        secondaryColor: '#1c0e38',
+        tertiaryColor: '#3d2860',
+        lineColor: '#ff9a3c',
+        textColor: '#ffe8d0',
+        mainBkg: '#1c0e38',
+        nodeBorder: '#ff9a3c',
+        clusterBkg: '#2a1a4a',
+        clusterBorder: '#ff9a3c',
+        titleColor: '#ffc8a0',
+        edgeLabelBackground: '#1c0e38',
+      },
+    });
+    mermaidInitialized = true;
+  }
+  return mermaid;
+};
+
+/** 블로그 본문 .ProseMirror 안의 mermaid 코드 블록을 SVG로 변환 */
+export const enhanceMermaidDiagrams = async (root: HTMLElement) => {
+  const blocks = root.querySelectorAll(MERMAID_CODE_SELECTOR);
+  if (blocks.length === 0) return;
+
+  const [mermaid, { sanitizeSvgHtml }] = await Promise.all([
+    initMermaid(),
+    import('@/shared/utils/sanitize-html'),
+  ]);
+
+  await Promise.all(
+    Array.from(blocks).map(async (block, index) => {
+      const source = getCodeBlockText(block);
+      if (!source) return;
+      try {
+        const id = `post-mermaid-${index}-${Date.now()}`;
+        const { svg } = await mermaid.render(id, source);
+        const pre = block.closest('pre');
+        if (pre) {
+          const safeSvg = sanitizeSvgHtml(svg);
+          pre.outerHTML = `<div class="mermaid-diagram my-4 overflow-x-auto rounded-lg border border-[#ff9a3c]/30 bg-[#1c0e38] p-4 dark:border-[#3de8ff]/30 dark:bg-[#070414]">${safeSvg}</div>`;
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.error('Mermaid render failed:', error);
+        }
+      }
+    }),
+  );
+};

--- a/src/shared/lib/pagination.ts
+++ b/src/shared/lib/pagination.ts
@@ -1,0 +1,32 @@
+type PaginationLike =
+  | {
+      currentPage?: number;
+      page?: number;
+      hasNextPage?: boolean;
+      totalPages?: number;
+    }
+  | null
+  | undefined;
+
+/** OpenAPI(nested) / legacy(flat meta) / category(pagination) 모두 지원 */
+export const getNextPageParamFromMeta = (
+  source: { meta?: { pagination?: PaginationLike } & PaginationLike; pagination?: PaginationLike } | null | undefined,
+): number | undefined => {
+  if (!source) return undefined;
+
+  const pagination = source.meta?.pagination ?? source.meta ?? source.pagination;
+  if (!pagination) return undefined;
+
+  const currentPage = pagination.currentPage ?? pagination.page;
+  if (!currentPage) return undefined;
+
+  if (typeof pagination.hasNextPage === 'boolean') {
+    return pagination.hasNextPage ? currentPage + 1 : undefined;
+  }
+
+  if (typeof pagination.totalPages === 'number') {
+    return currentPage < pagination.totalPages ? currentPage + 1 : undefined;
+  }
+
+  return undefined;
+};

--- a/src/shared/ui/PostContentViewer.tsx
+++ b/src/shared/ui/PostContentViewer.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect, useRef } from 'react';
+import { enhanceMermaidDiagrams } from '@/shared/lib/mermaid-render';
+
+const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'), {
+  ssr: false,
+  loading: () => <div className='blog-prose min-h-[120px]' aria-busy='true' role='status' />,
+});
+
+type PostContentViewerProps = {
+  content: string;
+};
+
+export const PostContentViewer = ({ content }: PostContentViewerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!content || !containerRef.current) return;
+
+    let cancelled = false;
+
+    const renderMermaid = () => {
+      if (cancelled || !containerRef.current) return false;
+      const proseRoot = containerRef.current.querySelector('.ProseMirror');
+      if (!proseRoot) return false;
+      void enhanceMermaidDiagrams(proseRoot as HTMLElement);
+      return true;
+    };
+
+    if (renderMermaid()) return;
+
+    const observer = new MutationObserver(() => {
+      if (renderMermaid()) observer.disconnect();
+    });
+
+    observer.observe(containerRef.current, { childList: true, subtree: true });
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [content]);
+
+  return (
+    <div ref={containerRef}>
+      <NovelViewer content={content} />
+    </div>
+  );
+};

--- a/src/shared/ui/PostHtmlViewer.tsx
+++ b/src/shared/ui/PostHtmlViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { preprocessHTML } from '@/shared/utils/process-html';
+import { getCodeBlockText, preprocessHTML } from '@/shared/utils/process-html';
 
 type PostHtmlViewerProps = {
   content: string;
@@ -9,8 +9,10 @@ type PostHtmlViewerProps = {
 
 let mermaidInitialized = false;
 
+const MERMAID_CODE_SELECTOR = 'pre code.language-mermaid, pre code[class*="language-mermaid"]';
+
 const enhanceCodeBlocks = async (root: HTMLElement) => {
-  const blocks = root.querySelectorAll('pre code.language-mermaid, pre code[class*="mermaid"]');
+  const blocks = root.querySelectorAll(MERMAID_CODE_SELECTOR);
   if (blocks.length === 0) return;
 
   const [{ default: mermaid }, { sanitizeSvgHtml }] = await Promise.all([
@@ -25,7 +27,7 @@ const enhanceCodeBlocks = async (root: HTMLElement) => {
 
   await Promise.all(
     Array.from(blocks).map(async (block, index) => {
-      const source = block.textContent?.trim();
+      const source = getCodeBlockText(block);
       if (!source) return;
       try {
         const id = `post-mermaid-${index}-${Date.now()}`;
@@ -35,8 +37,10 @@ const enhanceCodeBlocks = async (root: HTMLElement) => {
           const safeSvg = sanitizeSvgHtml(svg);
           pre.outerHTML = `<div class="mermaid-diagram my-4 overflow-x-auto">${safeSvg}</div>`;
         }
-      } catch {
-        // 원본 코드 블록 유지
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.error('Mermaid render failed:', error);
+        }
       }
     }),
   );
@@ -50,24 +54,21 @@ export default function PostHtmlViewer({ content }: PostHtmlViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const preprocessed = content ? preprocessHTML(content) : '';
   const [html, setHtml] = useState(preprocessed);
+  const [isSanitized, setIsSanitized] = useState(false);
 
   useEffect(() => {
     if (!content) {
       setHtml('');
+      setIsSanitized(false);
       return;
     }
 
     let cancelled = false;
 
-    void import('@/shared/utils/sanitize-html').then(async ({ sanitizePostHtml }) => {
+    void import('@/shared/utils/sanitize-html').then(({ sanitizePostHtml }) => {
       if (cancelled) return;
-      const sanitized = sanitizePostHtml(preprocessHTML(content));
-      setHtml(sanitized);
-      requestAnimationFrame(() => {
-        if (!cancelled && containerRef.current) {
-          void enhanceCodeBlocks(containerRef.current);
-        }
-      });
+      setHtml(sanitizePostHtml(preprocessHTML(content)));
+      setIsSanitized(true);
     });
 
     return () => {
@@ -75,9 +76,15 @@ export default function PostHtmlViewer({ content }: PostHtmlViewerProps) {
     };
   }, [content]);
 
+  useEffect(() => {
+    if (!isSanitized || !html || !containerRef.current) return;
+
+    void enhanceCodeBlocks(containerRef.current);
+  }, [html, isSanitized]);
+
   return (
     <div className='blog-prose'>
       <div ref={containerRef} className='ProseMirror' dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
-}
+};

--- a/src/shared/utils/process-html.ts
+++ b/src/shared/utils/process-html.ts
@@ -1,8 +1,20 @@
 // HTML 문자열에서 코드블럭 내부의 \n 개행 문자를 <br> 태그로 변환
+// mermaid 등 줄바꿈이 문법인 블록은 제외
 export const preprocessHTML = (html: string) => {
   return html.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/g, (match, content) => {
-    // 코드블럭 내부의 \n 개행 문자를 <br> 태그로 변환
+    if (/language-mermaid|class="[^"]*mermaid/i.test(match)) {
+      return match;
+    }
+
     const processedContent = content.replace(/\n/g, '<br>');
     return match.replace(content, processedContent);
   });
+};
+
+/** code 블록 텍스트 추출 (preprocessHTML의 <br> 변환 후에도 mermaid 소스 복원) */
+export const getCodeBlockText = (codeElement: Element) => {
+  const html = codeElement.innerHTML.replace(/<br\s*\/?>/gi, '\n');
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = html;
+  return textarea.value.trim();
 };

--- a/src/widgets/admin/home/ui/card-section.tsx
+++ b/src/widgets/admin/home/ui/card-section.tsx
@@ -1,12 +1,19 @@
+import { getStats } from '@/features/admin/home/api/stats-api';
+import { getUserCount } from '@/features/user/api/user-api';
+import { getVisitor } from '@/features/visitor/api';
 import { PostsCard, TotalViewsCard, UsersCard, VisitorsCard } from '@/features/admin/home/ui';
 
-export function SectionCards() {
+export async function SectionCards() {
+  const stats = await getStats();
+  const userCount = await getUserCount();
+  const visitor = await getVisitor();
+
   return (
     <div className='grid grid-cols-1 gap-4 px-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4 lg:px-6'>
-      <VisitorsCard />
-      <UsersCard />
-      <PostsCard />
-      <TotalViewsCard />
+      <VisitorsCard visitor={visitor} />
+      <UsersCard userCount={userCount} />
+      <PostsCard posts={stats.posts} />
+      <TotalViewsCard views={stats.views} />
     </div>
   );
 }

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -6,9 +6,10 @@ import { useCallback, useEffect, useRef } from 'react';
 import { getPostList } from '@/features/post/api/post-api';
 import type { GetPostListParams, GetPostListResponse } from '@/features/post/model';
 import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
+import { getNextPageParamFromMeta } from '@/shared/lib/pagination';
 import { queryKeys } from '@/shared/queryKeys';
-import { useBlogScrollRoot } from '@/widgets/post/ui/BlogScrollContext';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
+import { LoadMoreSentinel } from '@/widgets/post/ui/LoadMoreSentinel';
 import { BlogSectionTitle } from './BlogSectionTitle';
 import { NoResults } from './NoResults';
 import { PostList } from './PostList';
@@ -16,58 +17,6 @@ import { RecentPosts } from './RecentPosts';
 
 type BlogMainPageProps = {
   initialPosts?: GetPostListResponse;
-};
-
-type LoadMorePostsProps = {
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
-  onLoadMore: () => void;
-};
-
-const LoadMorePosts = ({ hasNextPage, isFetchingNextPage, onLoadMore }: LoadMorePostsProps) => {
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  const scrollRoot = useBlogScrollRoot();
-
-  useEffect(() => {
-    if (!hasNextPage) return;
-
-    const node = sentinelRef.current;
-    if (!node) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
-          onLoadMore();
-        }
-      },
-      {
-        root: scrollRoot,
-        rootMargin: '320px',
-        threshold: 0,
-      },
-    );
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore, scrollRoot]);
-
-  if (!hasNextPage && !isFetchingNextPage) {
-    return null;
-  }
-
-  return (
-    <div ref={sentinelRef} className='mt-8 flex justify-center'>
-      <button
-        type='button'
-        onClick={onLoadMore}
-        disabled={isFetchingNextPage || !hasNextPage}
-        className={`rounded-lg px-4 py-2 text-sm transition disabled:opacity-60 ${blogTheme.navBtn}`}
-        aria-label='다음 글 불러오기'
-      >
-        {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
-      </button>
-    </div>
-  );
 };
 
 export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
@@ -90,26 +39,19 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
 
   const { data, isLoading, isError, isSuccess, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery<GetPostListResponse>({
-    queryKey: queryKeys.post.all(listParams).queryKey,
-    queryFn: ({ pageParam = 1 }) => getPostList({ ...listParams, page: pageParam as number }),
-    initialPageParam: 1,
-    staleTime: 60_000,
-    initialData: canUseInitialData
-      ? {
-          pages: [initialPosts as GetPostListResponse],
-          pageParams: [1],
-        }
-      : undefined,
-    getNextPageParam: (lastPage) => {
-      const currentPage = lastPage.meta?.pagination?.currentPage;
-      const nextPageExists = lastPage.meta?.pagination?.hasNextPage;
-      if (nextPageExists && currentPage) {
-        return currentPage + 1;
-      }
-      return undefined;
-    },
-    placeholderData: keepPreviousData,
-  });
+      queryKey: queryKeys.post.all(listParams).queryKey,
+      queryFn: ({ pageParam = 1 }) => getPostList({ ...listParams, page: pageParam as number }),
+      initialPageParam: 1,
+      staleTime: 60_000,
+      initialData: canUseInitialData
+        ? {
+            pages: [initialPosts as GetPostListResponse],
+            pageParams: [1],
+          }
+        : undefined,
+      getNextPageParam: (lastPage) => getNextPageParamFromMeta(lastPage),
+      placeholderData: keepPreviousData,
+    });
 
   const postsData = data?.pages?.flatMap((page) => page.data ?? []) ?? [];
   const showLoading = isLoading && postsData.length === 0;
@@ -179,6 +121,14 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
     );
   }
 
+  const loadMore = (
+    <LoadMoreSentinel
+      hasNextPage={Boolean(hasNextPage)}
+      isFetchingNextPage={isFetchingNextPage}
+      onLoadMore={handleLoadMore}
+    />
+  );
+
   if (hasFilters) {
     const filterLabel = [
       search ? `"${search}"` : null,
@@ -192,11 +142,7 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
       <div className='mx-auto w-full max-w-4xl'>
         <BlogSectionTitle subtitle={filterLabel || '조건에 맞는 글'}>검색 결과</BlogSectionTitle>
         <PostList posts={postsData} isLoading={showLoading} />
-        <LoadMorePosts
-          hasNextPage={Boolean(hasNextPage)}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={handleLoadMore}
-        />
+        {loadMore}
       </div>
     );
   }
@@ -215,11 +161,7 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
           <PostList posts={restPosts} isLoading={showLoading} />
         </>
       )}
-      <LoadMorePosts
-        hasNextPage={Boolean(hasNextPage)}
-        isFetchingNextPage={isFetchingNextPage}
-        onLoadMore={handleLoadMore}
-      />
+      {loadMore}
     </div>
   );
 };

--- a/src/widgets/post/ui/BlogMainPage.tsx
+++ b/src/widgets/post/ui/BlogMainPage.tsx
@@ -2,11 +2,12 @@
 
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { getPostList } from '@/features/post/api/post-api';
 import type { GetPostListParams, GetPostListResponse } from '@/features/post/model';
 import { AnalyticsEvents, trackEvent } from '@/shared/lib/analytics';
 import { queryKeys } from '@/shared/queryKeys';
+import { useBlogScrollRoot } from '@/widgets/post/ui/BlogScrollContext';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { BlogSectionTitle } from './BlogSectionTitle';
 import { NoResults } from './NoResults';
@@ -25,6 +26,7 @@ type LoadMorePostsProps = {
 
 const LoadMorePosts = ({ hasNextPage, isFetchingNextPage, onLoadMore }: LoadMorePostsProps) => {
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const scrollRoot = useBlogScrollRoot();
 
   useEffect(() => {
     if (!hasNextPage) return;
@@ -38,12 +40,16 @@ const LoadMorePosts = ({ hasNextPage, isFetchingNextPage, onLoadMore }: LoadMore
           onLoadMore();
         }
       },
-      { rootMargin: '240px' },
+      {
+        root: scrollRoot,
+        rootMargin: '320px',
+        threshold: 0,
+      },
     );
 
     observer.observe(node);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+  }, [hasNextPage, isFetchingNextPage, onLoadMore, scrollRoot]);
 
   if (!hasNextPage && !isFetchingNextPage) {
     return null;
@@ -109,10 +115,10 @@ export const BlogMainPage = ({ initialPosts }: BlogMainPageProps) => {
   const showLoading = isLoading && postsData.length === 0;
   const trackedKeyRef = useRef<string>('');
 
-  const handleLoadMore = () => {
+  const handleLoadMore = useCallback(() => {
     if (!hasNextPage || isFetchingNextPage) return;
     fetchNextPage();
-  };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const handleRetry = () => {
     refetch();

--- a/src/widgets/post/ui/BlogScrollContext.tsx
+++ b/src/widgets/post/ui/BlogScrollContext.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export const BlogScrollContext = createContext<HTMLElement | null>(null);
+
+export const useBlogScrollRoot = () => useContext(BlogScrollContext);

--- a/src/widgets/post/ui/LoadMoreSentinel.tsx
+++ b/src/widgets/post/ui/LoadMoreSentinel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useBlogScrollRoot } from '@/widgets/post/ui/BlogScrollContext';
+import { blogTheme } from '@/widgets/post/ui/blog-theme';
+
+type LoadMoreSentinelProps = {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+};
+
+export const LoadMoreSentinel = ({ hasNextPage, isFetchingNextPage, onLoadMore }: LoadMoreSentinelProps) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const scrollRoot = useBlogScrollRoot();
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  onLoadMoreRef.current = onLoadMore;
+
+  const tryLoadMore = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    onLoadMoreRef.current();
+  }, [hasNextPage, isFetchingNextPage]);
+
+  useEffect(() => {
+    if (!hasNextPage) return;
+
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          tryLoadMore();
+        }
+      },
+      {
+        root: scrollRoot,
+        rootMargin: '400px',
+        threshold: 0,
+      },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasNextPage, scrollRoot, tryLoadMore]);
+
+  useEffect(() => {
+    if (!hasNextPage || !scrollRoot) return;
+
+    const handleScroll = () => {
+      const nearBottom = scrollRoot.scrollTop + scrollRoot.clientHeight >= scrollRoot.scrollHeight - 400;
+      if (nearBottom) tryLoadMore();
+    };
+
+    scrollRoot.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => scrollRoot.removeEventListener('scroll', handleScroll);
+  }, [hasNextPage, scrollRoot, tryLoadMore]);
+
+  if (!hasNextPage && !isFetchingNextPage) {
+    return null;
+  }
+
+  return (
+    <div ref={sentinelRef} className='mt-8 flex min-h-[48px] justify-center pb-8'>
+      <button
+        type='button'
+        onClick={tryLoadMore}
+        disabled={isFetchingNextPage || !hasNextPage}
+        className={`rounded-lg px-4 py-2 text-sm transition disabled:opacity-60 ${blogTheme.navBtn}`}
+        aria-label='다음 글 불러오기'
+      >
+        {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
+      </button>
+    </div>
+  );
+};

--- a/src/widgets/post/ui/PostsLayoutShell.tsx
+++ b/src/widgets/post/ui/PostsLayoutShell.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import { SpaceBackground } from '@/widgets/post/ui/SpaceBackground';
 import BlogHeader from '@/widgets/post/ui/BlogHeader';
 import Sidebar from '@/widgets/post/ui/Sidebar';
+import { BlogScrollContext } from '@/widgets/post/ui/BlogScrollContext';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 
 type PostsLayoutShellProps = {
@@ -11,25 +12,32 @@ type PostsLayoutShellProps = {
 };
 
 export const PostsLayoutShell = ({ children }: PostsLayoutShellProps) => {
+  const [scrollRoot, setScrollRoot] = useState<HTMLElement | null>(null);
+
   return (
     <div className={blogTheme.shellRoot}>
       <div className={`relative h-screen w-full overflow-hidden ${blogTheme.shell}`}>
         <SpaceBackground />
 
-        <div className='relative z-10 flex h-screen'>
-          <main className='flex flex-1 justify-center overflow-y-auto p-4 lg:p-10'>
-            <div className='w-full'>
-              <Suspense fallback={<div className='mx-auto mb-8 h-16 w-full max-w-4xl' />}>
-                <BlogHeader />
-              </Suspense>
-              {children}
-            </div>
-          </main>
+        <BlogScrollContext.Provider value={scrollRoot}>
+          <div className='relative z-10 flex h-screen'>
+            <main
+              ref={setScrollRoot}
+              className='flex flex-1 justify-center overflow-y-auto p-4 lg:p-10'
+            >
+              <div className='w-full'>
+                <Suspense fallback={<div className='mx-auto mb-8 h-16 w-full max-w-4xl' />}>
+                  <BlogHeader />
+                </Suspense>
+                {children}
+              </div>
+            </main>
 
-          <Suspense fallback={null}>
-            <Sidebar />
-          </Suspense>
-        </div>
+            <Suspense fallback={null}>
+              <Sidebar />
+            </Suspense>
+          </div>
+        </BlogScrollContext.Provider>
 
         <div
           className={`pointer-events-none absolute inset-x-0 bottom-0 z-[5] h-[32vh] ${blogTheme.bottomVeil}`}


### PR DESCRIPTION
## Summary
- admin 대시보드 DB 연결 한도 초과(Prisma max clients) 500 수정
- 블로그 상세 mermaid 다이어그램·코드블록(NovelViewer) 렌더 복구
- `/blog/all`·카테고리 목록 무한 스크롤 요청 미발생 수정 (`meta.pagination` 불일치 해결)
- LoadMoreSentinel 공통화 및 scroll+IntersectionObserver 이중 감지

## Test plan
- [ ] `/admin` 대시보드 카드 4개 정상 로드
- [ ] 블로그 상세 mermaid 차트 텍스트·코드블록 스타일 확인
- [ ] `/blog/all` 스크롤 시 page=2 API 요청
- [ ] `/blog/category/{slug}` 스크롤 시 다음 페이지 로드
- [ ] 태그 필터 `/blog/all?tags=...` 무한 스크롤