### PR TITLE
fix: 블로그 상세 코드블록 에디터 UI 복원

### DIFF
--- a/src/shared/ui/PostContentViewer.tsx
+++ b/src/shared/ui/PostContentViewer.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useEffect, useRef } from 'react';
-import { enhanceMermaidDiagrams } from '@/shared/lib/mermaid-render';
 
 const NovelViewer = dynamic(() => import('@/shared/ui/NovelViewer'), {
   ssr: false,
@@ -13,39 +11,7 @@ type PostContentViewerProps = {
   content: string;
 };
 
+/** NovelViewer + 에디터와 동일한 CodeBlock NodeView(언어 셀렉트·머메이드 미리보기) */
 export const PostContentViewer = ({ content }: PostContentViewerProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!content || !containerRef.current) return;
-
-    let cancelled = false;
-
-    const renderMermaid = () => {
-      if (cancelled || !containerRef.current) return false;
-      const proseRoot = containerRef.current.querySelector('.ProseMirror');
-      if (!proseRoot) return false;
-      void enhanceMermaidDiagrams(proseRoot as HTMLElement);
-      return true;
-    };
-
-    if (renderMermaid()) return;
-
-    const observer = new MutationObserver(() => {
-      if (renderMermaid()) observer.disconnect();
-    });
-
-    observer.observe(containerRef.current, { childList: true, subtree: true });
-
-    return () => {
-      cancelled = true;
-      observer.disconnect();
-    };
-  }, [content]);
-
-  return (
-    <div ref={containerRef}>
-      <NovelViewer content={content} />
-    </div>
-  );
+  return <NovelViewer content={content} />;
 };

--- a/src/shared/ui/TextEditor/code-block-extension.ts
+++ b/src/shared/ui/TextEditor/code-block-extension.ts
@@ -1,0 +1,26 @@
+import { CodeBlockLowlight } from 'novel/extensions';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { all, common, createLowlight } from 'lowlight';
+import CodeBlock from './code-block';
+
+export const createCodeBlockExtension = (scope: 'all' | 'common' = 'all') => {
+  const lowlight = scope === 'all' ? createLowlight(all) : createLowlight(common);
+
+  return CodeBlockLowlight.extend({
+    addAttributes() {
+      return {
+        ...this.parent?.(),
+        mode: {
+          default: 0,
+          parseHTML: (element) => Number.parseInt(element.getAttribute('data-mode') || '0', 10),
+          renderHTML: (attributes) => ({
+            'data-mode': attributes.mode,
+          }),
+        },
+      };
+    },
+    addNodeView() {
+      return ReactNodeViewRenderer(CodeBlock);
+    },
+  }).configure({ lowlight });
+};

--- a/src/shared/ui/TextEditor/code-block.tsx
+++ b/src/shared/ui/TextEditor/code-block.tsx
@@ -32,19 +32,31 @@ export enum Mode {
   Edit = 1,
 }
 
-export default function CodeBlock(props: any) {
+type CodeBlockProps = {
+  editor: { isEditable: boolean };
+  node: {
+    attrs: { language?: string | null; mode?: number };
+    textContent: string;
+  };
+  updateAttributes: (attrs: Record<string, unknown>) => void;
+  extension: { options: { lowlight: { listLanguages: () => string[] } } };
+};
+
+export default function CodeBlock(props: CodeBlockProps) {
   const { data: session } = useSession();
   const isAdmin = session?.user.role === 'ADMIN';
-  const { node, updateAttributes, extension } = props;
+  const { editor, node, updateAttributes, extension } = props;
   const {
     attrs: { language: defaultLanguage, mode = Mode.Edit },
     textContent,
   } = node;
   const previewer = useRef<HTMLPreElement>(null);
+  const isReadOnly = !editor.isEditable;
   const isMermaid = defaultLanguage === 'mermaid';
+  const effectiveMode = isReadOnly && isMermaid ? Mode.Preview : mode;
 
   useEffect(() => {
-    if (mode !== Mode.Preview || !previewer.current || !isMermaid || !textContent.trim()) {
+    if (effectiveMode !== Mode.Preview || !previewer.current || !isMermaid || !textContent.trim()) {
       return;
     }
 
@@ -55,7 +67,7 @@ export default function CodeBlock(props: any) {
         const mermaid = await ensureMermaid();
         if (cancelled || !previewer.current) return;
 
-        const id = `mermaid-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const id = `mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
         const textarea = document.createElement('textarea');
         textarea.innerHTML = textContent;
         const decodedTextContent = textarea.value;
@@ -80,25 +92,35 @@ export default function CodeBlock(props: any) {
     return () => {
       cancelled = true;
     };
-  }, [mode, textContent, isMermaid]);
+  }, [effectiveMode, textContent, isMermaid]);
+
+  const handleLanguageChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    if (isReadOnly) return;
+    updateAttributes({
+      language: event.target.value,
+      mode,
+    });
+  };
+
+  const handleToggleMermaidPreview = () => {
+    if (isReadOnly) return;
+    updateAttributes({
+      language: defaultLanguage,
+      mode: mode === Mode.Edit ? Mode.Preview : Mode.Edit,
+    });
+  };
 
   return (
-    <NodeViewWrapper>
-      <pre>
-        {/* 상단 컨트롤 바 */}
+    <NodeViewWrapper className='not-prose my-4'>
+      <div className='overflow-hidden rounded-md border border-gray-600 bg-slate-900'>
         <div className='flex items-center justify-between bg-gray-800 px-3 py-2'>
           <div className='flex items-center gap-2'>
-            {isMermaid && isAdmin && (
+            {isMermaid && isAdmin && !isReadOnly && (
               <button
                 type='button'
                 contentEditable={false}
-                onClick={() => {
-                  updateAttributes({
-                    language: defaultLanguage,
-                    mode: mode === Mode.Edit ? Mode.Preview : Mode.Edit,
-                  });
-                }}
-                className='text-xs font-medium px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 transition-colors text-white'
+                onClick={handleToggleMermaidPreview}
+                className='rounded-md bg-gray-700 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-600'
               >
                 {mode === Mode.Edit ? '미리보기' : '편집'}
               </button>
@@ -107,14 +129,11 @@ export default function CodeBlock(props: any) {
 
           <select
             contentEditable={false}
-            defaultValue={defaultLanguage}
-            onChange={(event) =>
-              updateAttributes({
-                language: event.target.value,
-                mode: mode,
-              })
-            }
-            className='text-xs px-3 py-1.5 rounded-md bg-gray-700 border border-gray-600 hover:bg-gray-600 transition-colors text-white'
+            value={defaultLanguage ?? 'null'}
+            onChange={handleLanguageChange}
+            disabled={isReadOnly}
+            aria-label='코드 블록 언어'
+            className='rounded-md border border-gray-600 bg-gray-700 px-3 py-1.5 text-xs text-white transition-colors hover:bg-gray-600 disabled:cursor-default disabled:opacity-90'
           >
             <option value='null' className='bg-gray-800 text-white'>
               auto
@@ -133,13 +152,22 @@ export default function CodeBlock(props: any) {
           </select>
         </div>
 
-        {/* 코드 블록 컨텐츠 */}
-        <pre hidden={isMermaid && mode === Mode.Preview} className='text-sm text-gray-100 overflow-x-auto'>
+        <pre
+          hidden={isMermaid && effectiveMode === Mode.Preview}
+          className='overflow-x-auto bg-slate-900 p-4 text-sm text-gray-100'
+        >
           <NodeViewContent as='code' />
         </pre>
 
-        {isMermaid && <pre contentEditable={false} hidden={mode === Mode.Edit} ref={previewer} />}
-      </pre>
+        {isMermaid && (
+          <pre
+            contentEditable={false}
+            hidden={effectiveMode === Mode.Edit}
+            ref={previewer}
+            className='overflow-x-auto bg-slate-900 p-4'
+          />
+        )}
+      </div>
     </NodeViewWrapper>
   );
 }

--- a/src/shared/ui/TextEditor/extensions.ts
+++ b/src/shared/ui/TextEditor/extensions.ts
@@ -1,7 +1,6 @@
 import {
   AIHighlight,
   CharacterCount,
-  CodeBlockLowlight,
   Color,
   CustomKeymap,
   GlobalDragHandle,
@@ -22,12 +21,9 @@ import {
   Youtube,
 } from 'novel/extensions';
 import { TableKit } from '@tiptap/extension-table';
-import { ReactNodeViewRenderer } from '@tiptap/react';
-import CodeBlock from './code-block';
 import { UploadImagesPlugin } from 'novel/plugins';
-
 import { cx } from 'class-variance-authority';
-import { all, createLowlight } from 'lowlight';
+import { createCodeBlockExtension } from './code-block-extension';
 
 // TODO I am using cx here to get tailwind autocomplete working, idk if someone else can write a regex to just capture the class key in objects
 const aiHighlight = AIHighlight;
@@ -120,27 +116,7 @@ const starterKit = StarterKit.configure({
   gapcursor: false,
 });
 
-const lowlight = createLowlight(all);
-
-const codeBlockLowlight = CodeBlockLowlight.extend({
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      mode: {
-        default: 0, // MODE.EDIT
-        parseHTML: (element) => Number.parseInt(element.getAttribute('data-mode') || '0'),
-        renderHTML: (attributes) => {
-          return {
-            'data-mode': attributes.mode,
-          };
-        },
-      },
-    };
-  },
-  addNodeView() {
-    return ReactNodeViewRenderer(CodeBlock);
-  },
-}).configure({ lowlight });
+const codeBlockLowlight = createCodeBlockExtension('all');
 
 const youtube = Youtube.configure({
   HTMLAttributes: {

--- a/src/shared/ui/TextEditor/viewerExtensions.ts
+++ b/src/shared/ui/TextEditor/viewerExtensions.ts
@@ -1,5 +1,4 @@
 import {
-  CodeBlockLowlight,
   Color,
   HighlightExtension,
   HorizontalRule,
@@ -16,7 +15,7 @@ import {
 } from 'novel/extensions';
 import { TableKit } from '@tiptap/extension-table';
 import { cx } from 'class-variance-authority';
-import { common, createLowlight } from 'lowlight';
+import { createCodeBlockExtension } from './code-block-extension';
 
 const tiptapLink = TiptapLink.configure({
   HTMLAttributes: {
@@ -91,14 +90,7 @@ const starterKit = StarterKit.configure({
   gapcursor: false,
 });
 
-const lowlight = createLowlight(common);
-
-const codeBlockLowlight = CodeBlockLowlight.configure({
-  lowlight,
-  HTMLAttributes: {
-    class: cx('rounded-md bg-muted text-muted-foreground border p-5 font-mono font-medium'),
-  },
-});
+const codeBlockLowlight = createCodeBlockExtension('all');
 
 const youtube = Youtube.configure({
   HTMLAttributes: {


### PR DESCRIPTION
## Summary
- 블로그 상세 코드블록에 에디터와 동일한 UI 복원 (상단 툴바 + 언어 셀렉트)
- viewerExtensions에 CodeBlock NodeView 적용
- 읽기 전용: 언어 셀렉트 disabled 표시, mermaid 자동 미리보기

## Test plan
- [ ] 블로그 상세 포스트 코드블록 상단 언어 셀렉트 표시
- [ ] syntax highlighting 정상
- [ ] mermaid 블록 차트 렌더 확인