### PR TITLE
fix: 블로그 목록→상세 진입 시 운영환경 404 수정

### DIFF
--- a/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
+++ b/app/(public)/blog/(posts)/category/[slug]/post/[postSlug]/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import type { PostResponse } from '@/entities/post/model/post';
 import { CommentSection } from '@/features/comment/ui';
-import { getPostBySlug } from '@/features/post/api/post-api';
-import { extractDescription, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
+import { getPostBySlugOnServer } from '@/features/post/api/get-post-by-slug.server';
+import { extractDescription, getPostPath, getPostUrl, toAbsoluteUrl } from '@/shared/consts/baseUrl';
+import { decodePathSegment } from '@/shared/lib/decode-path-segment';
 import { PostContentViewer } from '@/shared/ui/PostContentViewer';
 import { formatDateToYMD } from '@/shared/utils';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
@@ -18,10 +19,15 @@ const PostSummary = dynamic(() => import('@/shared/ui/PostSummary').then((mod) =
 
 export async function generateMetadata({ params }: { params: Promise<{ postSlug: string }> }): Promise<Metadata> {
   const { postSlug } = await params;
-  const decodedSlug = decodeURIComponent(postSlug);
+  const decodedSlug = decodePathSegment(postSlug);
 
   try {
-    const post = await getPostBySlug(decodedSlug);
+    const post = await getPostBySlugOnServer(decodedSlug);
+    if (!post) {
+      return {
+        title: '포스트를 찾을 수 없습니다',
+      };
+    }
     const description = extractDescription(post.content ?? '');
     const publishedDate = post.createdAt ? new Date(post.createdAt).toISOString() : undefined;
     const modifiedDate = post.updatedAt ? new Date(post.updatedAt).toISOString() : publishedDate;
@@ -119,22 +125,17 @@ const PostStructuredData = ({ post }: { post: PostResponse }) => {
 
 export default async function PostPage({ params }: { params: Promise<{ slug: string; postSlug: string }> }) {
   const { slug, postSlug } = await params;
-  const decodedSlug = decodeURIComponent(postSlug);
-  const categorySlug = decodeURIComponent(slug);
+  const decodedSlug = decodePathSegment(postSlug);
+  const categorySlug = decodePathSegment(slug);
 
-  let post: PostResponse;
-  try {
-    post = await getPostBySlug(decodedSlug);
-  } catch {
-    notFound();
-  }
+  const post = await getPostBySlugOnServer(decodedSlug);
 
   if (!post?.title || !post?.content) {
     notFound();
   }
 
   if (post.category?.slug && post.category.slug !== categorySlug) {
-    notFound();
+    redirect(getPostPath(post.category.slug, decodedSlug));
   }
 
   const backHref = `/blog/category/${post.category?.slug ?? categorySlug}`;

--- a/app/api/posts/[slug]/route.ts
+++ b/app/api/posts/[slug]/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import prisma from '@/shared/lib/db';
+import { decodePathSegment } from '@/shared/lib/decode-path-segment';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
 
 /**
  * @swagger
@@ -127,7 +129,8 @@ import prisma from '@/shared/lib/db';
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   try {
-    const { slug } = await params;
+    const { slug: rawSlug } = await params;
+    const slug = decodePathSegment(rawSlug);
     if (!slug || typeof slug !== 'string') {
       return NextResponse.json({ error: 'Invalid post slug' }, { status: 400 });
     }
@@ -142,50 +145,52 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
     const userAgent = req.headers.get('user-agent') || 'unknown';
 
     // 먼저 게시물 조회
-    const post = await prisma.post.findUnique({
-      where: { slug },
-      include: {
-        author: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-        category: true,
-        tags: true,
-        comments: {
-          include: {
-            author: {
-              select: {
-                id: true,
-                name: true,
-              },
+    const post = await withPrismaRetry(() =>
+      prisma.post.findUnique({
+        where: { slug },
+        include: {
+          author: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
             },
-            replies: {
-              include: {
-                author: {
-                  select: {
-                    id: true,
-                    name: true,
+          },
+          category: true,
+          tags: true,
+          comments: {
+            include: {
+              author: {
+                select: {
+                  id: true,
+                  name: true,
+                },
+              },
+              replies: {
+                include: {
+                  author: {
+                    select: {
+                      id: true,
+                      name: true,
+                    },
                   },
                 },
               },
             },
           },
-        },
-        likes: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                name: true,
+          likes: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                },
               },
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     if (!post) {
       return NextResponse.json({ error: 'Post not found' }, { status: 404 });
@@ -245,50 +250,52 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
     }
 
     // 조회수 업데이트된 게시물 정보 반환
-    const updatedPost = await prisma.post.findUnique({
-      where: { slug },
-      include: {
-        author: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-        category: true,
-        tags: true,
-        comments: {
-          include: {
-            author: {
-              select: {
-                id: true,
-                name: true,
-              },
+    const updatedPost = await withPrismaRetry(() =>
+      prisma.post.findUnique({
+        where: { slug },
+        include: {
+          author: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
             },
-            replies: {
-              include: {
-                author: {
-                  select: {
-                    id: true,
-                    name: true,
+          },
+          category: true,
+          tags: true,
+          comments: {
+            include: {
+              author: {
+                select: {
+                  id: true,
+                  name: true,
+                },
+              },
+              replies: {
+                include: {
+                  author: {
+                    select: {
+                      id: true,
+                      name: true,
+                    },
                   },
                 },
               },
             },
           },
-        },
-        likes: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                name: true,
+          likes: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                },
               },
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     return NextResponse.json(updatedPost, { status: 200 });
   } catch (error) {

--- a/src/features/blog/ui/PostListCard/PostListCard.tsx
+++ b/src/features/blog/ui/PostListCard/PostListCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { PostResponse } from '@/entities/post/model/post';
+import { getPostPath } from '@/shared/consts/baseUrl';
 import { formatDateToYMD } from '@/shared/utils';
 import { blogTheme } from '@/widgets/post/ui/blog-theme';
 import { motion } from 'framer-motion';
@@ -18,7 +19,7 @@ type PostListCardProps = {
 export const PostListCard = ({ post, categoryName, categorySlug }: PostListCardProps) => {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const href = `/blog/category/${categorySlug ?? post.category?.slug}/post/${post?.slug}`;
+  const href = getPostPath(categorySlug ?? post.category?.slug, post.slug ?? '');
   const categoryLabel = categoryName ?? post.category?.name;
 
   const handleNavigate = (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/src/features/post/api/get-post-by-slug.server.ts
+++ b/src/features/post/api/get-post-by-slug.server.ts
@@ -1,0 +1,32 @@
+import { cache } from 'react';
+import type { PostResponse } from '@/entities/post/model/post';
+import { decodePathSegment } from '@/shared/lib/decode-path-segment';
+import prisma from '@/shared/lib/db';
+import { withPrismaRetry } from '@/shared/lib/with-prisma-retry';
+
+const postInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  category: true,
+  tags: true,
+} as const;
+
+/** SSR에서 HTTP self-fetch 없이 slug로 게시물 조회 (Vercel cold start 404 방지) */
+export const getPostBySlugOnServer = cache(async (rawSlug: string): Promise<PostResponse | null> => {
+  const slug = decodePathSegment(rawSlug);
+  if (!slug) return null;
+
+  const post = await withPrismaRetry(() =>
+    prisma.post.findUnique({
+      where: { slug },
+      include: postInclude,
+    }),
+  );
+
+  return post as PostResponse | null;
+});

--- a/src/shared/lib/decode-path-segment.ts
+++ b/src/shared/lib/decode-path-segment.ts
@@ -1,0 +1,14 @@
+/** URL path segment을 최대 3회 decode (이중 인코딩 대응) */
+export const decodePathSegment = (value: string) => {
+  let decoded = value;
+  for (let i = 0; i < 3; i++) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+};

--- a/src/widgets/post/ui/RecentPosts.tsx
+++ b/src/widgets/post/ui/RecentPosts.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { PostCardSkeleton } from '@/shared/ui/skeleton';
 import { PostCard } from '@/features/blog/ui';
 import type { PostResponse } from '@/entities/post/model/post';
+import { getPostPath } from '@/shared/consts/baseUrl';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { LoaderCircle } from 'lucide-react';
@@ -38,7 +39,7 @@ export const RecentPosts = ({ posts, isLoading }: RecentPostsProps) => {
     <div className='grid grid-cols-2 sm:grid-cols-3 gap-4 mb-10'>
       {recentPosts.map((post, idx) => {
         const postKey = post.id ?? post.slug ?? `recent-${idx}`;
-        const href = `/blog/category/${post.category?.slug}/post/${post.slug}`;
+        const href = getPostPath(post.category?.slug, post.slug ?? '');
         const isCardPending = isPending && pendingHref === href;
 
         const handleNavigate = (event: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
## Summary
- 블로그 목록에서 글 클릭 시 운영환경에서 간헐적으로 404가 뜨던 문제 수정
- SSR에서 API self-fetch 실패(500)를 notFound로 오판하던 로직을 Prisma 직접 조회로 변경
- 카테고리 slug 불일치 시 404 대신 canonical URL로 redirect
- 목록/RecentPosts 링크에 getPostPath 적용으로 slug 인코딩 통일

## Test plan
- [ ] Vercel 배포 후 `/blog/all` 목록에서 글 클릭 → 상세 404 없이 진입
- [ ] 카테고리 목록(`/blog/category/{slug}`)에서 글 클릭 정상 동작
- [ ] 한글 slug 포함 글 URL 정상 렌더
- [ ] 잘못된 카테고리 slug로 접근 시 redirect 동작 확인
- [ ] 존재하지 않는 slug는 404 유지


Made with [Cursor](https://cursor.com)